### PR TITLE
fix : incorrect value for language field in whatsapp_templates

### DIFF
--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_templates/whatsapp_templates.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_templates/whatsapp_templates.py
@@ -14,9 +14,7 @@ class WhatsAppTemplates(Document):
     def after_insert(self):
         """Set template code."""
         self.template_name = self.template_name.lower().replace(' ', '_')
-        self.language_code = frappe.db.get_value(
-            "Language", self.language
-        ).replace('-', '_')
+        self.language_code = frappe.db.get_list('Language', filters={'language_name': ['=', self.language]})[0].name.replace('-', '_')
 
         self.get_settings()
         data = {


### PR DESCRIPTION
language field in whatsapp_templates is equivalent to language_name field of 'Language' doctype