### PR TITLE
fix: file_name should be required only when custom_attachment is 1

### DIFF
--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/whatsapp_notification.js
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/whatsapp_notification.js
@@ -39,10 +39,10 @@ frappe.ui.form.on('WhatsApp Notification', {
 		)
 	},
 	custom_attachment: function(frm){
-		if(frm.doc.custom_attachment &&  ['DOCUMENT', "IMAGE"].includes(frm.doc.header_type)){
+		if(frm.doc.custom_attachment==1 &&  ['DOCUMENT', "IMAGE"].includes(frm.doc.header_type)){
 			frm.set_df_property('file_name', 'reqd', frm.doc.custom_attachment)
 		}else{
-			frm.set_df_property('file_name', 'reqd', !frm.doc.custom_attachment)
+			frm.set_df_property('file_name', 'reqd', 0)
 		}
 
 		// frm.toggle_display("attach_document_print", !frm.doc.custom_attachment);

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/whatsapp_notification.js
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/whatsapp_notification.js
@@ -39,7 +39,7 @@ frappe.ui.form.on('WhatsApp Notification', {
 		)
 	},
 	custom_attachment: function(frm){
-		if(frm.doc.custom_attachment==1 &&  ['DOCUMENT', "IMAGE"].includes(frm.doc.header_type)){
+		if(frm.doc.custom_attachment == 1 &&  ['DOCUMENT', "IMAGE"].includes(frm.doc.header_type)){
 			frm.set_df_property('file_name', 'reqd', frm.doc.custom_attachment)
 		}else{
 			frm.set_df_property('file_name', 'reqd', 0)


### PR DESCRIPTION
custom_attachment is checkbox and hence frm.doc.custom_attachment always evaluates to true, we need to do frm.doc.custom_attachment==1  to make file_name as required.