### PR TITLE
fix: on uninstall --> pymysql.err.ProgrammingError: ('DocType', 'WhatsApp Notification')

### DIFF
--- a/frappe_whatsapp/utils/__init__.py
+++ b/frappe_whatsapp/utils/__init__.py
@@ -14,6 +14,10 @@ def run_server_script_for_doc_event(doc, event):
 
     if frappe.flags.in_migrate:
         return
+    
+    if frappe.flags.in_uninstall:
+        return
+
     notification = get_notifications_map().get(
         doc.doctype, {}
     ).get(EVENT_MAP[event], None)


### PR DESCRIPTION
# FIx: On Uninstall --> pymysql.err.ProgrammingError: ('DocType', 'WhatsApp Notification')

## Description

Whenever we try to uninstall frappe_whatsapp app from our site it throws below error: 
```
(env) frappe@4d87b8042f64:~/frappe-bench$ bench uninstall-app frappe_whatsapp
Uninstalling App frappe_whatsapp from Site site1.local...
All doctypes (including custom), modules related to this app will be deleted. Are you sure you want to continue? [y/N]: y
Backing up...
Deleting Module 'Frappe Whatsapp'
* removing Module Def 'Frappe Whatsapp'...
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 114, in <module>
    main()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 20, in main
    click.Group(commands=commands)(prog_name="bench")
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 29, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py", line 873, in uninstall
    remove_app(app_name=app, dry_run=dry_run, yes=yes, no_backup=no_backup, force=force)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/installer.py", line 396, in remove_app
    drop_doctypes = _delete_modules(modules, dry_run=dry_run)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/installer.py", line 441, in _delete_modules
    frappe.delete_doc("Module Def", module_name, ignore_on_trash=True, force=True)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1392, in delete_doc
    return frappe.model.delete_doc.delete_doc(
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/delete_doc.py", line 144, in delete_doc
    doc.run_method("after_delete")
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 962, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1322, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1306, in runner
    add_to_return_value(self, f(self, method, *args, **kwargs))
  File "/home/frappe/frappe-bench/apps/frappe_whatsapp/frappe_whatsapp/utils/__init__.py", line 17, in run_server_script_for_doc_event
    notification = get_notifications_map().get(
  File "/home/frappe/frappe-bench/apps/frappe_whatsapp/frappe_whatsapp/utils/__init__.py", line 36, in get_notifications_map
    enabled_whatsapp_notifications = frappe.get_all(
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 2057, in get_all
    return get_list(doctype, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 2032, in get_list
    return frappe.model.db_query.DatabaseQuery(doctype).execute(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 185, in execute
    self.columns = self.get_table_columns()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 546, in get_table_columns
    return get_table_columns(self.doctype)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/meta.py", line 73, in get_table_columns
    return frappe.db.get_table_columns(doctype)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 1197, in get_table_columns
    raise self.TableMissingError("DocType", doctype)
pymysql.err.ProgrammingError: ('DocType', 'WhatsApp Notification')
```

Fixes # (issue)
This error was occurring because we're calling a function called `run_server_script_for_doc_event` on doc events which also calls during uninstall event so I've added a condition for frappe.flags.in_uninstall if this is true it will return and don't execute code

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
