### PR TITLE
fix: get template actual name instead of template document name

### DIFF
--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/whatsapp_notification.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/whatsapp_notification.py
@@ -35,6 +35,10 @@ class WhatsAppNotification(Document):
             "WhatsApp Templates", self.template,
             fieldname='language_code'
         )
+        template_actual_name = frappe.db.get_value(
+            "WhatsApp Templates", self.template,
+            fieldname='actual_name'
+        )
         if language_code:
             for contact in self._contact_list:
                 data = {
@@ -42,7 +46,7 @@ class WhatsAppNotification(Document):
                     "to": self.format_number(contact),
                     "type": "template",
                     "template": {
-                        "name": self.template,
+                        "name": template_actual_name,
                         "language": {
                             "code": language_code
                         },
@@ -77,7 +81,7 @@ class WhatsAppNotification(Document):
                 "to": self.format_number(doc_data[self.field_name]),
                 "type": "template",
                 "template": {
-                    "name": self.template,
+                    "name": template.actual_name,
                     "language": {
                         "code": template.language_code
                     },


### PR DESCRIPTION
While sending messages using notification 
it shows this error message: "(#132001) Template name does not exist in the translation"