### PR TITLE
Create pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "frappe_whatsapp"
+authors = [
+    { name = "Shridhar Patil", email = "shrip.dev@gmail.com"}
+]
+description = "WhatsApp integration for frappe. Use directly meta API's without any 3rd party integration."
+requires-python = ">=3.10"
+readme = "README.md"
+dynamic = ["version"]
+dependencies = [
+    "python-magic~=0.4.24",
+]
+
+[build-system]
+requires = ["flit_core >=3.4,<4"]
+build-backend = "flit_core.buildapi"
+
+# These dependencies are only installed when developer mode is enabled
+[tool.bench.dev-dependencies]
+# package_name = "~=1.1.0"
+
+[tool.bench.frappe-dependencies]
+frappe = ">=15.0.0-dev,<17.0.0"


### PR DESCRIPTION
Created pyproject.toml file to resolve error message during install "DEPRECATION: Legacy editable install of frappe-whatsapp==1.0.7 from file:///home/erp/frappe-bench/apps/frappe_whatsapp (setup.py develop) is deprecated. pip 25.0 will enforce this behaviour change. A possible replacement is to add a pyproject.toml or enable --use-pep517, and use setuptools >= 64. If the resulting installation is not behaving as expected, try using --config-settings editable_mode=compat. Please consult the setuptools documentation for more information. Discussion can be found at https://github.com/pypa/pip/issues/11457"