### PR TITLE
test: fixed failing unit test

### DIFF
--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/test_whatsapp_message.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/test_whatsapp_message.py
@@ -3,10 +3,10 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestWhatsAppMessage(FrappeTestCase):
+class TestWhatsAppMessage(UnitTestCase):
     """Test whatsapp messages."""
 
     pass

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/test_whatsapp_notification.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/test_whatsapp_notification.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestWhatsAppNotification(FrappeTestCase):
+class TestWhatsAppNotification(UnitTestCase):
 	pass

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification_log/test_whatsapp_notification_log.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification_log/test_whatsapp_notification_log.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestWhatsAppNotificationLog(FrappeTestCase):
+class TestWhatsAppNotificationLog(UnitTestCase):
 	pass

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_settings/test_whatsapp_settings.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_settings/test_whatsapp_settings.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestWhatsAppSettings(FrappeTestCase):
+class TestWhatsAppSettings(UnitTestCase):
 	pass

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_templates/test_whatsapp_templates.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_templates/test_whatsapp_templates.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests import UnitTestCase
 
 
-class TestWhatsAppTemplates(FrappeTestCase):
+class TestWhatsAppTemplates(UnitTestCase):
 	pass


### PR DESCRIPTION
Fixed failing unit test with below error
```
frappe.testing.discovery.TestRunnerError: Failed to discover tests for ['crm']: function() argument 'code' must be code, not str
```
**Cause:**
PR Link: https://github.com/frappe/frappe/pull/28044