### PR TITLE
feat: better way to do WhatsApp Notification with Notification Type "…

### DIFF
--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/whatsapp_notification.js
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/whatsapp_notification.js
@@ -42,6 +42,9 @@ frappe.notification = {
 			// set date changed options
 			frm.set_df_property("date_changed", "options", get_date_change_options());
 
+			// set value changed options
+			frm.set_df_property("value_changed", "options", [""].concat(options));
+			frm.set_df_property("set_property_after_alert", "options", [""].concat(options));
 		});
 	},
 	setup_alerts_button: function (frm) {

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/whatsapp_notification.json
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/whatsapp_notification.json
@@ -28,13 +28,15 @@
   "condition",
   "column_break_12",
   "fields",
+  "property_section",
+  "set_property_after_alert",
+  "property_value",
   "help_section",
   "help_html",
   "header_type"
  ],
  "fields": [
   {
-   "depends_on": "eval:['DocType Event', 'Permission Query'].includes(doc.notification_type)",
    "fieldname": "reference_doctype",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -76,7 +78,7 @@
   {
    "fieldname": "help_html",
    "fieldtype": "HTML",
-   "options": "<pre><code>doc.grand_total &gt; 0</code></pre>\n\n<p>Conditions should be written in simple Python. Please use properties available in the form only.</p>\n\n<p>Example: </p><pre><code>doc.status=='Enabled' </code></pre><p></p>\n\n<p> For scheduler events you can use follwing methods</p>\n<p>Allowed functions: </p><ul>\n<li>frappe.db.get_value</li>\n<li>frappe.db.get_list</li>\n<li>frappe.session</li>\n<li>frappe.utils.now_datetime</li>\n<li>frappe.utils.get_datetime</li>\n<li>frappe.utils.add_to_date</li>\n<li>frappe.utils.now</li>\n</ul>\n<p>Example: </p><pre><code>doc.creation &gt; frappe.utils.add_to_date(frappe.utils.now_datetime(\n), days=-5, as_string=True, as_datetime=True) </code></pre><p></p>\n\n<p>\n\t<b>\n\t\tFinally set the contact list to send messages. This should be set only in case of scheduled events.\n\t</b>\n<br>\ndoc._contact_list = [\"919123456789\"]\n</p> "
+   "options": "<pre><code>doc.grand_total &gt; 0</code></pre>\n\n<p>Conditions should be written in simple Python. Please use properties available in the form only.</p>\n\n<p>Example: </p><pre><code>doc.status=='Enabled' </code></pre><p></p>\n\n<p> For scheduler events you can use follwing methods</p>\n<p>Allowed functions: </p><ul>\n<li>frappe.db.get_value</li>\n<li>frappe.db.get_list</li>\n<li>frappe.session</li>\n<li>frappe.utils.now_datetime</li>\n<li>frappe.utils.get_datetime</li>\n<li>frappe.utils.add_to_date</li>\n<li>frappe.utils.now</li>\n</ul>\n<p>Example: </p><pre><code>doc.creation &gt; frappe.utils.add_to_date(frappe.utils.now_datetime(\n), days=-5, as_string=True, as_datetime=True) </code></pre><p></p>\n\n<p>\n\t<strong>For scheduled events, use </strong>\n<br>\n1. Simple template sending, without parameters, just send a template\n</p><pre><code class=\"language-python\">\ndoc.set(\"_contact_list\", [\"919123456789\"])\n</code>\n</pre>\n\n2. Message based on doctype with parameters\n<pre><code class=\"language-python\">\nquotation_list = frappe.get_list(\"Quotation\", {\"name\": \"VEN-COT-24-29806\", \"custom_whatsapp_notify\": 0})\nfor qo in quotation_list:\n\tdata_list.append({\n\t\t\"name\": qo.name,\n\t\t\"phone_no\": \"5548996436821\",\n\t})\ndoc.set(\"_data_list\", data_list)\n</code>\n</pre>\n\n<p></p> "
   },
   {
    "fieldname": "notification_type",
@@ -101,12 +103,11 @@
    "options": "Python Expression"
   },
   {
-   "depends_on": "eval:['DocType Event'].includes(doc.notification_type)",
    "description": "Mobile number field",
    "fieldname": "field_name",
    "fieldtype": "Data",
    "label": "Field Name",
-   "reqd": 1
+   "mandatory_depends_on": "eval:['DocType Event'].includes(doc.notification_type)"
   },
   {
    "fieldname": "column_break_12",
@@ -170,6 +171,21 @@
    "label": "Attach from field "
   },
   {
+   "fieldname": "property_section",
+   "fieldtype": "Section Break",
+   "label": "Set Property After Alert"
+  },
+  {
+   "fieldname": "set_property_after_alert",
+   "fieldtype": "Select",
+   "label": "Set Property After Alert"
+  },
+  {
+   "fieldname": "property_value",
+   "fieldtype": "Data",
+   "label": "Value To Be Set"
+  },
+  {
    "depends_on": "eval:doc.doctype_event==='Days Before' || doc.doctype_event==='Days After'",
    "description": "Send days before or after the reference date",
    "fieldname": "days_in_advance",
@@ -196,7 +212,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-08-24 13:53:36.666204",
+ "modified": "2024-10-31 19:23:24.483369",
  "modified_by": "Administrator",
  "module": "Frappe Whatsapp",
  "name": "WhatsApp Notification",

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/whatsapp_notification.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/whatsapp_notification.py
@@ -2,6 +2,8 @@
 
 import json
 import frappe
+
+from frappe import _dict, _
 from frappe.model.document import Document
 from frappe.utils.safe_exec import get_safe_globals, safe_exec
 from frappe.integrations.utils import make_post_request
@@ -22,64 +24,94 @@ class WhatsAppNotification(Document):
                 fields=["fieldname"]
             )
             if not any(field.fieldname == self.field_name for field in fields): # noqa
-                frappe.throw(f"Field name {self.field_name} does not exists")
+                frappe.throw(_("Field name {0} does not exists").format(self.field_name))
         if self.custom_attachment:
             if not self.attach and not self.attach_from_field:
-                frappe.throw("Either <b>Attach</b> a file or add a <b>Attach from field</b> to send attachemt")
+                frappe.throw(_("Either {0} a file or add a {1} to send attachemt").format(
+                    frappe.bold(_("Attach")),
+                    frappe.bold(_("Attach from field")),
+                ))
+
+        if self.set_property_after_alert:
+            meta = frappe.get_meta(self.reference_doctype)
+            if not meta.get_field(self.set_property_after_alert):
+                frappe.throw(_("Field {0} not found on DocType {1}").format(
+                    self.set_property_after_alert,
+                    self.reference_doctype,
+                ))
+
 
     def send_scheduled_message(self) -> dict:
         """Specific to API endpoint Server Scripts."""
         safe_exec(
             self.condition, get_safe_globals(), dict(doc=self)
         )
-        language_code = frappe.db.get_value(
-            "WhatsApp Templates", self.template,
-            fieldname='language_code'
-        )
-        template_actual_name = frappe.db.get_value(
-            "WhatsApp Templates", self.template,
-            fieldname='actual_name'
-        )
-        if language_code:
-            for contact in self._contact_list:
-                data = {
-                    "messaging_product": "whatsapp",
-                    "to": self.format_number(contact),
-                    "type": "template",
-                    "template": {
-                        "name": template_actual_name,
-                        "language": {
-                            "code": language_code
-                        },
-                        "components": []
-                    }
-                }
-                self.content_type = template.get("header_type", "text").lower()
-                self.notify(data)
-        # return _globals.frappe.flags
-
-    def send_template_message(self, doc: Document):
-        """Specific to Document Event triggered Server Scripts."""
-        if self.disabled:
-            return
-
-        doc_data = doc.as_dict()
-        if self.condition:
-            # check if condition satisfies
-            if not frappe.safe_eval(
-                self.condition, get_safe_globals(), dict(doc=doc_data)
-            ):
-                return
 
         template = frappe.db.get_value(
             "WhatsApp Templates", self.template,
             fieldname='*'
         )
 
-        if template:
+        if template and template.language_code:
+            if self.get("_contact_list"):
+                # send simple template without a doc to get field data.
+                self.send_simple_template(template)
+            elif self.get("_data_list"):
+                # allow send a dynamic template using schedule event config
+                # _doc_list shoud be [{"name": "xxx", "phone_no": "123"}]
+                for data in self._data_list:
+                    doc = frappe.get_doc(self.reference_doctype, data.get("name"))
+
+                    self.send_template_message(doc, data.get("phone_no"), template, True)
+        # return _globals.frappe.flags
+
+
+    def send_simple_template(self, template):
+        """ send simple template without a doc to get field data """
+        for contact in self._contact_list:
             data = {
                 "messaging_product": "whatsapp",
-                "to": self.format_number(doc_data[self.field_name]),
+                "to": self.format_number(contact),
+                "type": "template",
+                "template": {
+                    "name": template.actual_name,
+                    "language": {
+                        "code": template.language_code
+                    },
+                    "components": []
+                }
+            }
+            self.content_type = template.get("header_type", "text").lower()
+            self.notify(data)
+
+
+    def send_template_message(self, doc: Document, phone_no=None, default_template=None, ignore_condition=False):
+        """Specific to Document Event triggered Server Scripts."""
+        if self.disabled:
+            return
+
+        doc_data = doc.as_dict()
+        if self.condition and not ignore_condition:
+            # check if condition satisfies
+            if not frappe.safe_eval(
+                self.condition, get_safe_globals(), dict(doc=doc_data)
+            ):
+                return
+
+        template = default_template or frappe.db.get_value(
+            "WhatsApp Templates", self.template,
+            fieldname='*'
+        )
+
+        if template:
+            if self.field_name:
+                phone_number = phone_no or doc_data[self.field_name]
+            else:
+                phone_number = phone_no
+
+            data = {
+                "messaging_product": "whatsapp",
+                "to": self.format_number(phone_number),
                 "type": "template",
                 "template": {
                     "name": template.actual_name,
@@ -94,9 +126,14 @@ class WhatsAppNotification(Document):
             if self.fields:
                 parameters = []
                 for field in self.fields:
-                    value = doc_data[field.field_name]
-                    if isinstance(doc_data[field.field_name], (datetime.date, datetime.datetime)):
-                        value = str(doc_data[field.field_name])
+                    if isinstance(doc, Document):
+                        # get field with prettier value.
+                        value = doc.get_formatted(field.field_name)
+                    else: 
+                        value = doc_data[field.field_name]
+                        if isinstance(doc_data[field.field_name], (datetime.date, datetime.datetime)):
+                            value = str(doc_data[field.field_name])
+
                     parameters.append({
                         "type": "text",
                         "text": value
@@ -175,9 +212,9 @@ class WhatsAppNotification(Document):
                 })
             self.content_type = template.header_type.lower()
 
-            self.notify(data)
+            self.notify(data, doc_data)
 
-    def notify(self, data):
+    def notify(self, data, doc_data=None):
         """Notify."""
         settings = frappe.get_doc(
             "WhatsApp Settings", "WhatsApp Settings",
@@ -198,15 +235,35 @@ class WhatsAppNotification(Document):
             if not self.get("content_type"):
                 self.content_type = 'text'
 
-            frappe.get_doc({
+            new_doc = {
                 "doctype": "WhatsApp Message",
                 "type": "Outgoing",
                 "message": str(data['template']),
                 "to": data['to'],
                 "message_type": "Template",
                 "message_id": response['messages'][0]['id'],
-                "content_type": self.content_type
-            }).save(ignore_permissions=True)
+                "content_type": self.content_type,
+            }
+
+            if doc_data:
+                new_doc.update({
+                    "reference_doctype": doc_data.doctype,
+                    "reference_name": doc_data.name,
+                })
+
+            frappe.get_doc(new_doc).save(ignore_permissions=True)
+
+            if doc_data and self.set_property_after_alert and self.property_value:
+                if doc_data.doctype and doc_data.name:
+                    fieldname = self.set_property_after_alert
+                    value = self.property_value
+                    meta = frappe.get_meta(doc_data.get("doctype"))
+                    df = meta.get_field(fieldname)
+                    if df:
+                        if df.fieldtype in frappe.model.numeric_fieldtypes:
+                            value = frappe.utils.cint(value)
+
+                        frappe.db.set_value(doc_data.get("doctype"), doc_data.get("name"), fieldname, value)
 
             frappe.msgprint("WhatsApp Message Triggered", indicator="green", alert=True)
             success = True
@@ -233,26 +290,52 @@ class WhatsAppNotification(Document):
                 "meta_data": meta
             }).insert(ignore_permissions=True)
 
+
     def on_trash(self):
         """On delete remove from schedule."""
         if self.notification_type == "Scheduler Event":
-            frappe.delete_doc("Scheduled Job Type", self.name)
+            exists_more_events = frappe.db.exists(
+                "WhatsApp Notification",
+                {
+                    "name": ["!=", self.name],
+                    "event_frequency": self.event_frequency,
+                }
+            )
+
+            if not exists_more_events:
+                # if doesnt exists more scheduler events for the "event_frequency", remove schedule jobs
+                method = self.get_event_method()
+                schedule_job = frappe.db.exists("Scheduled Job Type", {
+                    "method": method,
+                    "frequency": self.event_frequency,
+                })
+
+                if schedule_job:
+                    frappe.delete_doc("Scheduled Job Type", schedule_job)
 
         frappe.cache().delete_value("whatsapp_notification_map")
+
+
+    def get_event_method(self):
+        return f"frappe_whatsapp.utils.trigger_whatsapp_notifications_{self.event_frequency.lower().replace(' ', '_')}" # noqa
 
     def after_insert(self):
         """After insert hook."""
         if self.notification_type == "Scheduler Event":
-            method = f"frappe_whatsapp.utils.trigger_whatsapp_notifications_{self.event_frequency.lower().replace(' ', '_')}" # noqa
-            job = frappe.get_doc(
-                {
-                    "doctype": "Scheduled Job Type",
-                    "method": method,
-                    "frequency": self.event_frequency
-                }
-            )
+            method = self.get_event_method()
 
-            job.insert()
+            if not frappe.db.exists("Scheduled Job Type", {
+                "method": method,
+            }):
+                job = frappe.get_doc(
+                    {
+                        "doctype": "Scheduled Job Type",
+                        "method": method,
+                        "frequency": self.event_frequency
+                    }
+                )
+
+                job.insert()
 
     def format_number(self, number):
         """Format number."""
@@ -260,7 +343,6 @@ class WhatsAppNotification(Document):
             number = number[1:len(number)]
 
         return number
-
 
     def get_documents_for_today(self):
         """get list of documents that will be triggered today"""

--- a/frappe_whatsapp/utils/__init__.py
+++ b/frappe_whatsapp/utils/__init__.py
@@ -107,8 +107,16 @@ def trigger_whatsapp_notifications_monthly_long():
 
 def trigger_whatsapp_notifications(event):
     """Run cron."""
-    frappe.get_doc(
+    wa_notify_list = frappe.get_list(
         "WhatsApp Notification",
-        frappe.db.get_value("WhatsApp Notification", filters={"event_frequency": event})
-    ).send_scheduled_message()
-    pass
+        filters={
+            "event_frequency": event,
+            "disabled": 0,
+        }
+    )
+
+    for wa in wa_notify_list:
+        frappe.get_doc(
+            "WhatsApp Notification",
+            wa.name,
+        ).send_scheduled_message()


### PR DESCRIPTION
This change aims to improve the way of creating events to trigger WhatsApp notifications.


1. Created a way to set a field on relative doctype on send a whatsapp message, for this was created a section called "Set Property After Alert"

2. Allow created more then one WhatsApp Notification with Notification Type "Event Schedule" for the same "Event Frequency" but with diferente propouse

Event method was ajusted to look for a list of events...

3. method "send_scheduled_message" was refactored to allow send template using for a Event Schedule

4. Every message sended try to add doc references "reference_doctype" and "reference_name" and create a whatsapp message

5. Refactored the creationg of "Scheduled Job Type" on insert or delete a "WhatsApp Notification"

6. Better text formating for fields parameters using "doc.get_formatted(field.field_name)"