### PR TITLE
feat: allow to send whatsapp template with custom data dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ https://developers.facebook.com/docs/whatsapp/cloud-api/get-started
 
 ### Sending text message without creating template Create an entry in the WhatsApp message. On save it will trigger and whats app API to send a message ![image](https://user-images.githubusercontent.com/11792643/211518862-de2d3fbc-69c8-48e1-b000-8eebf20b75ab.png) WhatsApp messages are received via WhatsApp cloud API.![image](https://user-images.githubusercontent.com/11792643/211519625-a528abe2-ba24-46a4-bcbc-170f6b4e27fb.png) ![outgoing (1)](https://user-images.githubusercontent.com/11792643/211518647-45bfaa00-b06a-49c6-a3b3-3cf801d5ec68.gif) 
 
+### Sending a template using custom _dict() insted of a doctype.
+This can be very useful for features where it is not possible to get the values directly from the doctype.
+Just create a script and populate variable called "_data_list":
+`doc.set("_data_list", data_list)`
+
+Example:
+![image](https://github.com/user-attachments/assets/7496b081-df2b-41dc-bdcb-ed7e5f464698)
+
 ### Incomming message 
 * Setup webhook on meta 
 * Add verify token on meta and update the same on whatsapp settings 

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.py
@@ -68,12 +68,21 @@ class WhatsAppMessage(Document):
             parameters = []
             template_parameters = []
 
-            ref_doc = frappe.get_doc(self.reference_doctype, self.reference_name)
-            for field_name in field_names:
-                value = ref_doc.get_formatted(field_name.strip())
+            if self.flags.custom_ref_doc:
+                custom_values = self.flags.custom_ref_doc
+                for field_name in field_names:
+                    value = custom_values.get(field_name.strip())
+                    parameters.append({"type": "text", "text": value})
+                    template_parameters.append(value)                    
 
-                parameters.append({"type": "text", "text": value})
-                template_parameters.append(value)
+            else:
+                ref_doc = frappe.get_doc(self.reference_doctype, self.reference_name)
+                for field_name in field_names:
+                    value = ref_doc.get_formatted(field_name.strip())
+
+                    parameters.append({"type": "text", "text": value})
+                    template_parameters.append(value)
+
 
             self.template_parameters = json.dumps(template_parameters)
 


### PR DESCRIPTION
The purpose of this change is to open up more possibilities when messaging/automation with WhatsApp is performed via Python, with more dynamic logic.


Currently, template messages need to have a related document to retrieve the values... however, there are some needs that will not have a document and for which we need to send a template.

Situation 1.

The user will reset the password on the website and will receive a token on WhatsApp. This token is not stored anywhere.

Situation 2.

The user will receive a message informing them that their lab tests are ready. The message content will contain their password to access this test, which is related to the patient...

