### PR TITLE
refactory: Whatsapp Notification scheduler events must be setted on hook.py

### DIFF
--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/whatsapp_notification.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/whatsapp_notification.py
@@ -235,24 +235,8 @@ class WhatsAppNotification(Document):
 
     def on_trash(self):
         """On delete remove from schedule."""
-        if self.notification_type == "Scheduler Event":
-            frappe.delete_doc("Scheduled Job Type", self.name)
-
         frappe.cache().delete_value("whatsapp_notification_map")
 
-    def after_insert(self):
-        """After insert hook."""
-        if self.notification_type == "Scheduler Event":
-            method = f"frappe_whatsapp.utils.trigger_whatsapp_notifications_{self.event_frequency.lower().replace(' ', '_')}" # noqa
-            job = frappe.get_doc(
-                {
-                    "doctype": "Scheduled Job Type",
-                    "method": method,
-                    "frequency": self.event_frequency
-                }
-            )
-
-            job.insert()
 
     def format_number(self, number):
         """Format number."""

--- a/frappe_whatsapp/hooks.py
+++ b/frappe_whatsapp/hooks.py
@@ -115,18 +115,34 @@ app_include_js = "/assets/frappe_whatsapp/js/frappe_whatsapp.js"
 # ---------------
 
 scheduler_events = {
-#   "all": [
-#       "frappe_whatsapp.tasks.all"
-#   ],
-  "daily": [
-      "frappe_whatsapp.frappe_whatsapp.doctype.whatsapp_notification.whatsapp_notification.trigger_notifications"
-  ],
-#   "weekly": [
-#       "frappe_whatsapp.tasks.weekly"
-#   ],
-#   "monthly": [
-#       "frappe_whatsapp.tasks.monthly"
-#   ],
+    "all": [
+        "frappe_whatsapp.utils.trigger_whatsapp_notifications_all"
+    ],
+    "hourly": [
+        "frappe_whatsapp.utils.trigger_whatsapp_notifications_hourly"
+    ],
+    "hourly_long": [
+        "frappe_whatsapp.utils.trigger_whatsapp_notifications_hourly_long"
+    ],
+    "daily": [
+        "frappe_whatsapp.utils.trigger_whatsapp_notifications_daily",
+        "frappe_whatsapp.frappe_whatsapp.doctype.whatsapp_notification.whatsapp_notification.trigger_notifications",
+    ],
+    "daily_long": [
+        "frappe_whatsapp.utils.trigger_whatsapp_notifications_daily_long",
+    ],
+    "weekly": [
+        "frappe_whatsapp.utils.trigger_whatsapp_notifications_weekly",
+    ],
+    "weekly_long": [
+        "frappe_whatsapp.utils.trigger_whatsapp_notifications_weekly_long",
+    ],
+    "monthly": [
+        "frappe_whatsapp.utils.trigger_whatsapp_notifications_monthly",
+    ],
+    "monthly_long": [
+        "frappe_whatsapp.utils.trigger_whatsapp_notifications_monthly_long",
+    ],
 }
 
 # Testing


### PR DESCRIPTION
Problem: Every time you run migrate, the events inserted in the **Scheduled Job Type** doctype are deleted.

Reference frappe code:
https://github.com/frappe/frappe/blob/59309f8164f6a360017004324495f456844a49ce/frappe/migrate.py#L141

Frappe limitation:
Currently, the Frappe structure only allows you to create dynamic events for server scripts...

All other events must be in the application's hooks.py, otherwise they will be deleted on run migrate