### PR TITLE
feat: Fetch sender's profile name from WhatsApp webhook

### DIFF
--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.json
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.json
@@ -11,6 +11,7 @@
   "status",
   "to",
   "from",
+  "profile_name",
   "use_template",
   "template",
   "template_parameters",
@@ -182,11 +183,17 @@
    "fieldtype": "Data",
    "hidden": 1,
    "label": "bulk_message_reference"
-  }
+  },
+  {
+    "fieldname": "profile_name",
+    "fieldtype": "Data",
+    "label": "Profile Name",
+    "read_only": 1
+   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-03-02 12:23:22.908305",
+ "modified": "2025-03-13 12:03:12.896651",
  "modified_by": "Administrator",
  "module": "Frappe Whatsapp",
  "name": "WhatsApp Message",

--- a/frappe_whatsapp/utils/webhook.py
+++ b/frappe_whatsapp/utils/webhook.py
@@ -41,6 +41,16 @@ def post():
 		messages = data["entry"][0]["changes"][0]["value"].get("messages", [])
 	except KeyError:
 		messages = data["entry"]["changes"][0]["value"].get("messages", [])
+	sender_profile_name = next(
+		(
+			contact.get("profile", {}).get("name")
+			for entry in data.get("entry", [])
+			for change in entry.get("changes", [])
+			for contact in change.get("value", {}).get("contacts", [])
+		),
+		None,
+	)
+
 
 	if messages:
 		for message in messages:
@@ -56,7 +66,8 @@ def post():
 					"message_id": message['id'],
 					"reply_to_message_id": reply_to_message_id,
 					"is_reply": is_reply,
-					"content_type":message_type
+					"content_type":message_type,
+					"profile_name":sender_profile_name
 				}).insert(ignore_permissions=True)
 			elif message_type == 'reaction':
 				frappe.get_doc({
@@ -66,7 +77,8 @@ def post():
 					"message": message['reaction']['emoji'],
 					"reply_to_message_id": message['reaction']['message_id'],
 					"message_id": message['id'],
-					"content_type": "reaction"
+					"content_type": "reaction",
+					"profile_name":sender_profile_name
 				}).insert(ignore_permissions=True)
 			elif message_type == 'interactive':
 				frappe.get_doc({
@@ -75,7 +87,8 @@ def post():
 					"from": message['from'],
 					"message": message['interactive']['nfm_reply']['response_json'],
 					"message_id": message['id'],
-					"content_type": "flow"
+					"content_type": "flow",
+					"profile_name":sender_profile_name
 				}).insert(ignore_permissions=True)
 			elif message_type in ["image", "audio", "video", "document"]:
 				settings = frappe.get_doc(
@@ -112,7 +125,8 @@ def post():
 							"reply_to_message_id": reply_to_message_id,
 							"is_reply": is_reply,
 							"message": message[message_type].get("caption",f"/files/{file_name}"),
-							"content_type" : message_type
+							"content_type" : message_type,
+							"profile_name":sender_profile_name
 						}).insert(ignore_permissions=True)
 
 						file = frappe.get_doc(
@@ -138,7 +152,8 @@ def post():
 					"message_id": message['id'],
 					"reply_to_message_id": reply_to_message_id,
 					"is_reply": is_reply,
-					"content_type": message_type
+					"content_type": message_type,
+					"profile_name":sender_profile_name
 				}).insert(ignore_permissions=True)
 			else:
 				frappe.get_doc({
@@ -147,7 +162,8 @@ def post():
 					"from": message['from'],
 					"message_id": message['id'],
 					"message": message[message_type].get(message_type),
-					"content_type" : message_type
+					"content_type" : message_type,
+					"profile_name":sender_profile_name
 				}).insert(ignore_permissions=True)
 
 	else:


### PR DESCRIPTION
#### **Summary**  
This PR adds functionality to extract and store the sender’s **WhatsApp profile name** from the webhook response. The profile name is now saved in the **WhatsApp Message Doctype** under a new field `profile_name`.  

#### **Changes Made**  
- Extracts `profile.name` from the `contacts` section of the webhook response.  
- Stores it in the `profile_name` field in the **WhatsApp Message Doctype**.  
- Uses a clean and efficient `next()` approach for extraction.  


#### **Why This is Needed**  
- Previously, only the phone number was stored, making it harder to identify the sender.  
- This improves usability by associating a **human-readable name** with messages.  
