### PR TITLE
feat: Support WhatsApp template buttons (Quick Reply, Call Phone, Visit Website)

### DIFF
--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_button/whatsapp_button.json
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_button/whatsapp_button.json
@@ -1,0 +1,72 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-09-03 20:37:30.105094",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "button_type",
+  "button_label",
+  "sequence",
+  "is_active",
+  "phone_number",
+  "website_url",
+  "example_url",
+  "url_type"
+ ],
+ "fields": [
+  {
+   "fieldname": "button_type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Button Type",
+   "options": "Quick Reply\nCall Phone\nVisit Website",
+   "reqd": 1
+  },
+  {
+   "fieldname": "button_label",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Button Label",
+   "reqd": 1
+  },
+  {
+   "depends_on": "eval:doc.button_type == \"Call Phone\"",
+   "fieldname": "phone_number",
+   "fieldtype": "Data",
+   "label": "Phone Number"
+  },
+  {
+   "depends_on": "eval:doc.button_type == \"Visit Website\"",
+   "fieldname": "website_url",
+   "fieldtype": "Data",
+   "label": "Website URL"
+  },
+  {
+   "depends_on": "eval:doc.button_type == \"Visit Website\"",
+   "fieldname": "url_type",
+   "fieldtype": "Select",
+   "label": "URL Type",
+   "options": "Static\nDynamic"
+  },
+  {
+   "depends_on": "eval:doc.button_type == \"Visit Website\"",
+   "fieldname": "example_url",
+   "fieldtype": "Data",
+   "label": "Example URL"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-09-09 02:32:30.359644",
+ "modified_by": "Administrator",
+ "module": "Frappe Whatsapp",
+ "name": "WhatsApp Button",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_button/whatsapp_button.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_button/whatsapp_button.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2025, Shridhar Patil and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class WhatsAppButton(Document):
+	pass

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.py
@@ -109,6 +109,38 @@ class WhatsAppMessage(Document):
                     }]
                 })
 
+        if template.buttons:
+            button_parameters = []
+            for idx, btn in enumerate(template.buttons):
+                if btn.button_type == "Quick Reply":
+                    button_parameters.append({
+                        "type": "button",
+                        "sub_type": "quick_reply",
+                        "index": str(idx),
+                        "parameters": [{"type": "payload", "payload": btn.button_label}]
+                    })
+                elif btn.button_type == "Call Phone":
+                    button_parameters.append({
+                        "type": "button",
+                        "sub_type": "phone_number",
+                        "index": str(idx),
+                        "parameters": [{"type": "text", "text": btn.phone_number}]
+                    })
+                elif btn.button_type == "Visit Website":
+                    url = btn.website_url
+                    if btn.url_type == "Dynamic":
+                        ref_doc = frappe.get_doc(self.reference_doctype, self.reference_name)
+                        url = ref_doc.get_formatted(btn.website_url)
+                    button_parameters.append({
+                        "type": "button",
+                        "sub_type": "url",
+                        "index": str(idx),
+                        "parameters": [{"type": "text", "text": url}]
+                    })
+
+            if button_parameters:
+                data['template']['components'].extend(button_parameters)
+
         self.notify(data)
 
     def notify(self, data):

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/whatsapp_notification.json
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/whatsapp_notification.json
@@ -28,6 +28,7 @@
   "condition",
   "column_break_12",
   "fields",
+  "button_fields",
   "property_section",
   "set_property_after_alert",
   "property_value",
@@ -208,11 +209,17 @@
    "label": "Notification Name",
    "reqd": 1,
    "unique": 1
+  },
+  {
+   "description": "fields to replace button variables, separated by comma",
+   "fieldname": "button_fields",
+   "fieldtype": "Data",
+   "label": "Button Fields"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-03-03 11:30:47.397819",
+ "modified": "2025-09-18 02:11:52.149544",
  "modified_by": "Administrator",
  "module": "Frappe Whatsapp",
  "name": "WhatsApp Notification",

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/whatsapp_notification.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/whatsapp_notification.py
@@ -98,10 +98,7 @@ class WhatsAppNotification(Document):
             ):
                 return
 
-        template = default_template or frappe.db.get_value(
-            "WhatsApp Templates", self.template,
-            fieldname='*'
-        )
+        template = default_template or frappe.get_doc("WhatsApp Templates", self.template)
 
         if template:
             if self.field_name:
@@ -211,6 +208,20 @@ class WhatsAppNotification(Document):
                     }]
                 })
             self.content_type = template.header_type.lower()
+
+            if template.buttons:
+                button_fields = self.button_fields.split(",") if self.button_fields else []
+                for idx, btn in enumerate(template.buttons):
+                    if btn.button_type == "Visit Website" and btn.url_type == "Dynamic":
+                        if button_fields:
+                            data['template']['components'].append({
+                                "type": "button",
+                                "sub_type": "url",
+                                "index": str(idx),
+                                "parameters": [
+                                    {"type": "text", "text": doc.get(button_fields.pop(0))}
+                                ]
+                            })
 
             self.notify(data, doc_data)
 

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_templates/whatsapp_templates.json
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_templates/whatsapp_templates.json
@@ -26,7 +26,9 @@
   "header",
   "sample",
   "column_break_tbvf",
-  "footer"
+  "footer",
+  "section_break_wu2vp",
+  "buttons"
  ],
  "fields": [
   {
@@ -146,11 +148,21 @@
    "fieldname": "field_names",
    "fieldtype": "Small Text",
    "label": "Field names"
+  },
+  {
+   "fieldname": "buttons",
+   "fieldtype": "Table",
+   "label": "Buttons",
+   "options": "WhatsApp Button"
+  },
+  {
+   "fieldname": "section_break_wu2vp",
+   "fieldtype": "Section Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-08-19 12:22:17.367586",
+ "modified": "2025-09-03 20:39:48.979892",
  "modified_by": "Administrator",
  "module": "Frappe Whatsapp",
  "name": "WhatsApp Templates",

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_templates/whatsapp_templates.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_templates/whatsapp_templates.py
@@ -100,6 +100,27 @@ class WhatsAppTemplates(Document):
         # add footer
         if self.footer:
             data["components"].append({"type": "FOOTER", "text": self.footer})
+        
+        # add buttons
+        if self.buttons:
+            button_block = {"type": "BUTTONS", "buttons": []}
+            for btn in self.buttons:
+                b = {"type": btn.button_type, "text": btn.button_label}
+
+                if btn.button_type == "Visit Website":
+                    b["type"] = "URL"
+                    b["url"] = btn.website_url
+                    if btn.url_type == "Dynamic" and btn.example_url:
+                        b["example"] = btn.example_url.split(",")
+                elif btn.button_type == "Call Phone":
+                    b["type"] = "PHONE_NUMBER"
+                    b["phone_number"] = btn.phone_number
+                elif btn.button_type == "Quick Reply":
+                    b["type"] = "QUICK_REPLY"
+
+                button_block["buttons"].append(b)
+
+            data["components"].append(button_block)
 
         try:
             response = make_post_request(
@@ -134,6 +155,32 @@ class WhatsAppTemplates(Document):
             data["components"].append(self.get_header())
         if self.footer:
             data["components"].append({"type": "FOOTER", "text": self.footer})
+        if self.buttons:
+            print("\n\nyes buttons")
+            button_block = {"type": "BUTTONS", "buttons": []}
+            for btn in self.buttons:
+                b = {"type": btn.button_type, "text": btn.button_label}
+
+                if btn.button_type == "Visit Website":
+                    b["type"] = "URL"
+                    b["url"] = btn.website_url
+                    if btn.url_type == "Dynamic" and btn.example_url:
+                        b["example"] = btn.example_url.split(",")
+                elif btn.button_type == "Call Phone":
+                    b["type"] = "PHONE_NUMBER"
+                    b["phone_number"] = btn.phone_number
+                elif btn.button_type == "Quick Reply":
+                    b["type"] = "QUICK_REPLY"
+
+                button_block["buttons"].append(b)
+
+            data["components"].append(button_block)
+        print("\n\n")
+        print(f"{self._url}/{self._version}/{self.id}\n")
+        print("\n\n")
+        print(self._headers)
+        print("\n\n")
+        print(json.dumps(data))
         try:
             # post template to meta for update
             make_post_request(
@@ -256,13 +303,44 @@ def fetch():
                         doc.sample_values = ",".join(
                             component["example"]["body_text"][0]
                         )
+                
+                # Update buttons
+                elif component["type"] == "BUTTONS":
+                    frappe.db.delete("WhatsApp Button", {"parent": doc.name, "parenttype": "WhatsApp Templates"})
+                    typeMap = {
+                        "URL": "Visit Website",
+                        "PHONE_NUMBER": "Call Phone",
+                        "QUICK_REPLY": "Quick Reply"
+                    }
+
+                    for i, button in enumerate(component.get("buttons", []), start=1):
+                        btn = {}
+                        btn["button_type"] = typeMap[button["type"]]
+                        btn["button_label"] = button.get("text")
+                        btn["sequence"] = i
+
+                        if button["type"] == "URL":
+                            btn["website_url"] = button.get("url")
+                            if "{{" in btn["website_url"]:
+                                btn["url_type"] = "Dynamic"
+                            else:
+                                btn["url_type"] = "Static"
+                                
+                            if button.get("example"):
+                                btn["example_url"] = ",".join(button["example"])
+                        elif button["type"] == "PHONE_NUMBER":
+                            btn["phone_number"] = button.get("phone_number")
+                        
+                        doc.append("buttons", btn)
 
             # if document exists update else insert
             # used db_update and db_insert to ignore hooks
             if flags:
                 doc.db_update()
+                doc.db_update_all()
             else:
                 doc.db_insert()
+                doc.db_update_all()
             frappe.db.commit()
 
     except Exception as e:


### PR DESCRIPTION
This PR adds support for interactive buttons in WhatsApp templates via the Cloud API.

- New child table WhatsApp Button linked to WhatsApp Templates.
- fetch() now imports button definitions from Meta.
- after_insert pushes buttons to Meta when creating a template.
- Extended message sending to support dynamic URL placeholders.