### PR TITLE
Whatsapp Button Type flow in Whatsapp Templates

### DIFF
--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_button/whatsapp_button.json
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_button/whatsapp_button.json
@@ -21,7 +21,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Button Type",
-   "options": "Quick Reply\nCall Phone\nVisit Website\nComplete Flow",
+   "options": "Quick Reply\nCall Phone\nVisit Website\nFlow",
    "reqd": 1
   },
   {

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_templates/whatsapp_templates.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_templates/whatsapp_templates.py
@@ -320,7 +320,7 @@ def fetch():
                             "URL": "Visit Website",
                             "PHONE_NUMBER": "Call Phone",
                             "QUICK_REPLY": "Quick Reply",
-                            "FLOW": "Complete Flow"
+                            "FLOW": "Flow"
                         }
 
                         for i, button in enumerate(component.get("buttons", []), start=1):


### PR DESCRIPTION
Added Button type for Flow

<img width="1152" height="273" alt="image" src="https://github.com/user-attachments/assets/c092e9aa-98cf-419e-90fb-68dd4bff4403" />

Without button type of flow, there is an error and not able to fetch templates from Meta, previously we could fetch templates even without saving the button details

  File "apps/frappe_whatsapp/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_templates/whatsapp_templates.py", line 327, in fetch
    btn["button_type"] = typeMap[button["type"]]
KeyError: 'FLOW'
