### PR TITLE
fix: add support for s3 file urls

### DIFF
--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.py
@@ -242,6 +242,18 @@ class WhatsAppMessage(Document):
                         }]
                     })
 
+                elif template.header_type == 'DOCUMENT':
+                    data['template']['components'].append({
+                        "type": "header",
+                        "parameters": [{
+                            "type": "document",
+                            "document": {
+                                "link": url,
+                                "filename": "document.pdf"  # should be configurable
+                            }
+                        }]
+                    })
+
             elif template.sample:
                 if template.header_type == 'IMAGE':
                     if template.sample.startswith("http"):

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.py
@@ -226,12 +226,11 @@ class WhatsAppMessage(Document):
 
         if template.header_type:
             if self.attach:
+                if self.attach.startswith("http"):
+                    url = f'{self.attach}'
+                else:
+                    url = f'{frappe.utils.get_url()}{self.attach}'
                 if template.header_type == 'IMAGE':
-
-                    if self.attach.startswith("http"):
-                        url = f'{self.attach}'
-                    else:
-                        url = f'{frappe.utils.get_url()}{self.attach}'
                     data['template']['components'].append({
                         "type": "header",
                         "parameters": [{

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_templates/whatsapp_templates.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_templates/whatsapp_templates.py
@@ -81,7 +81,7 @@ class WhatsAppTemplates(Document):
             file_path = f'{frappe.utils.get_bench_path()}/sites/{frappe.utils.get_site_base_path()[2:]}/public{file_name}'
         if(file_name.startswith('/private/')):
             file_path = f'{frappe.utils.get_bench_path()}/sites/{frappe.utils.get_site_base_path()[2:]}{file_name}'
-        return file_path
+        return file_name
 
 
     def after_insert(self):


### PR DESCRIPTION
I am using frappe_s3_attachment which is storing valid url in file_name so its breaking for that with error

<img width="587" height="238" alt="image" src="https://github.com/user-attachments/assets/27052280-0252-4882-b02f-ae5572f14390" />
