### PR TITLE
feat: Custom option for event_frequency field in WhatsApp Notification doctype

### DIFF
--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/whatsapp_notification.json
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/whatsapp_notification.json
@@ -48,6 +48,7 @@
   },
   {
    "depends_on": "eval:doc.notification_type == \"Scheduler Event\"",
+   "description": "Tip: You can use \"Custom\" when you don\u2019t want a default frequency, but you must set up the custom schedule manually after selecting this option.",
    "fieldname": "event_frequency",
    "fieldtype": "Select",
    "label": "Event Frequency",
@@ -219,7 +220,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-02-04 16:56:52.149544",
+ "modified": "2026-02-09 08:57:16.575175",
  "modified_by": "Administrator",
  "module": "Frappe Whatsapp",
  "name": "WhatsApp Notification",

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/whatsapp_notification.json
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/whatsapp_notification.json
@@ -52,7 +52,7 @@
    "fieldtype": "Select",
    "label": "Event Frequency",
    "mandatory_depends_on": "eval:doc.script_type == \"Scheduler Event\"",
-   "options": "All\nHourly\nDaily\nWeekly\nMonthly\nYearly\nHourly Long\nDaily Long\nWeekly Long\nMonthly Long"
+   "options": "All\nHourly\nDaily\nWeekly\nMonthly\nYearly\nHourly Long\nDaily Long\nWeekly Long\nMonthly Long\nCustom"
   },
   {
    "depends_on": "eval:doc.notification_type==='DocType Event'",
@@ -219,7 +219,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-09-18 02:11:52.149544",
+ "modified": "2026-02-04 16:56:52.149544",
  "modified_by": "Administrator",
  "module": "Frappe Whatsapp",
  "name": "WhatsApp Notification",


### PR DESCRIPTION
### Add **Custom** option to `event_frequency` in WhatsApp Notification

This PR adds a new **Custom** option to the `event_frequency` field in the `WhatsApp Notification` doctype.

The goal is to allow WhatsApp notifications to be triggered by **custom schedules or custom logic**, instead of being limited only to the predefined frequencies (Daily, Weekly, etc.).
This makes the doctype consistent with Frappe’s built-in `Notification` doctype and enables use cases where notifications are sent through custom background jobs or scripted triggers.

#### Why this change is valid

Frappe’s core `Notification` doctype already supports the **Custom** option for the same purpose:

[https://github.com/frappe/frappe/blob/48e52e152b22b6e28b999da5056bde67b20bda81/frappe/email/doctype/notification/notification.json#L138](https://github.com/frappe/frappe/blob/48e52e152b22b6e28b999da5056bde67b20bda81/frappe/email/doctype/notification/notification.json#L138)

By adding the same option to `WhatsApp Notification`, we:

* Keep feature parity with Frappe’s standard Notification system
* Enable developers to schedule WhatsApp notifications programmatically
* Avoid forcing users to misuse fixed frequencies for custom jobs

#### Impact

* No breaking changes
* Existing notifications continue to work as before
* New workflows can use `Custom` for advanced scheduling