### PR TITLE
feat: add Subscribe App to Webhooks action on WhatsApp Account

### DIFF
--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_account/whatsapp_account.js
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_account/whatsapp_account.js
@@ -1,8 +1,32 @@
 // Copyright (c) 2025, Shridhar Patil and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("WhatsApp Account", {
-// 	refresh(frm) {
-
-// 	},
-// });
+frappe.ui.form.on("WhatsApp Account", {
+	refresh(frm) {
+		if (!frm.is_new()) {
+			frm.add_custom_button(__("Subscribe App to Webhooks"), () => {
+				frappe.confirm(
+					__("Subscribe this app to webhooks for WhatsApp Business Account {0}?", [
+						frm.doc.business_id || frm.doc.account_name,
+					]),
+					() => {
+						frm.call({
+							doc: frm.doc,
+							method: "subscribe_app",
+							freeze: true,
+							freeze_message: __("Subscribing app to webhooks..."),
+							callback: (r) => {
+								if (!r.exc) {
+									frappe.show_alert({
+										message: __("App subscribed to webhooks"),
+										indicator: "green",
+									});
+								}
+							},
+						});
+					}
+				);
+			});
+		}
+	},
+});

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_account/whatsapp_account.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_account/whatsapp_account.py
@@ -1,7 +1,11 @@
 # Copyright (c) 2025, Shridhar Patil and contributors
 # For license information, please see license.txt
 
+import json
+
 import frappe
+from frappe import _
+from frappe.integrations.utils import make_post_request
 from frappe.model.document import Document
 
 
@@ -23,3 +27,44 @@ class WhatsAppAccount(Document):
 				whatsapp_account = frappe.get_doc("WhatsApp Account", whatsapp_account.name)
 				whatsapp_account.set(field, 0)
 				whatsapp_account.save()
+
+	@frappe.whitelist()
+	def subscribe_app(self):
+		"""Subscribe this app to webhooks for the WhatsApp Business Account.
+
+		Required after phone number registration to receive incoming messages.
+		Calls POST /{version}/{business_id}/subscribed_apps on the Graph API.
+		"""
+		for field in ("url", "version", "business_id"):
+			if not self.get(field):
+				frappe.throw(_("{0} is required to subscribe the app").format(
+					frappe.bold(self.meta.get_label(field))
+				))
+
+		token = self.get_password("token")
+		if not token:
+			frappe.throw(_("Access token is required to subscribe the app"))
+
+		endpoint = f"{self.url}/{self.version}/{self.business_id}/subscribed_apps"
+		headers = {
+			"authorization": f"Bearer {token}",
+			"content-type": "application/json",
+		}
+
+		try:
+			response = make_post_request(endpoint, headers=headers, data=json.dumps({}))
+		except Exception as e:
+			error_message = str(e)
+			if frappe.flags.integration_request:
+				err = frappe.flags.integration_request.json().get("error", {})
+				if err:
+					error_message = err.get("message") or err.get("Error") or error_message
+			frappe.throw(_("Failed to subscribe app to webhooks: {0}").format(error_message))
+
+		if not response.get("success"):
+			frappe.throw(_("Subscription was not successful: {0}").format(frappe.as_json(response)))
+
+		frappe.logger().info(
+			f"WhatsApp app subscribed to webhooks for business_id={self.business_id}"
+		)
+		return response


### PR DESCRIPTION
Calls POST /{version}/{business_id}/subscribed_apps on the Graph API so that the WABA starts delivering incoming messages to the configured webhook after phone number registration.

Fixes https://github.com/shridarpatil/frappe_whatsapp/issues/208