### PR TITLE
fix(template): don't emit static Call Phone / Visit Website buttons 

### DIFF
--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/test_whatsapp_message.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/test_whatsapp_message.py
@@ -358,25 +358,35 @@ class TestWhatsAppMessage(IntegrationTestCase):
                 "whatsapp_account": "Test WA Msg Account",
                 "status": "APPROVED",
                 "id": "test_template_buttons_id",
-            })
-            tmpl.append("buttons", {
-                "button_type": "Quick Reply",
-                "button_label": "Yes",
-            })
-            tmpl.append("buttons", {
-                "button_type": "Call Phone",
-                "button_label": "Call Us",
-                "phone_number": "+919876543210",
-            })
-            tmpl.append("buttons", {
-                "button_type": "Visit Website",
-                "button_label": "Homepage",
-                "website_url": "https://example.com",
-                "url_type": "Static",
+                "name": template_name,
             })
             tmpl.flags.ignore_validate = True
             tmpl.db_insert()
-            for row in tmpl.buttons:
+            # Link child rows manually — append() before the parent has a
+            # name leaves parent blank, so we wire them up here.
+            buttons = [
+                {"button_type": "Quick Reply", "button_label": "Yes"},
+                {
+                    "button_type": "Call Phone",
+                    "button_label": "Call Us",
+                    "phone_number": "+919876543210",
+                },
+                {
+                    "button_type": "Visit Website",
+                    "button_label": "Homepage",
+                    "website_url": "https://example.com",
+                    "url_type": "Static",
+                },
+            ]
+            for idx, data in enumerate(buttons, start=1):
+                row = frappe.get_doc({
+                    "doctype": "WhatsApp Button",
+                    "parent": template_name,
+                    "parenttype": "WhatsApp Templates",
+                    "parentfield": "buttons",
+                    "idx": idx,
+                    **data,
+                })
                 row.db_insert()
             frappe.db.commit()
 

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/test_whatsapp_message.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/test_whatsapp_message.py
@@ -335,3 +335,65 @@ class TestWhatsAppMessage(IntegrationTestCase):
         self.assertTrue(
             frappe.db.exists("WhatsApp Message", {"to": "919900112263", "message_type": "Template"})
         )
+
+    @patch("frappe_whatsapp.frappe_whatsapp.doctype.whatsapp_message.whatsapp_message.make_post_request")
+    def test_send_template_omits_static_buttons(self, mock_post):
+        """Static Call Phone / Visit Website buttons must NOT appear in the
+        outgoing components payload — Meta rejects sub_type=phone_number and
+        applies static buttons from the approved template automatically.
+        See issue #188.
+        """
+        mock_post.return_value = {"messages": [{"id": "wamid.test_buttons"}]}
+
+        template_name = "test_msg_buttons_template-en"
+        if not frappe.db.exists("WhatsApp Templates", template_name):
+            tmpl = frappe.get_doc({
+                "doctype": "WhatsApp Templates",
+                "template_name": "test_msg_buttons_template",
+                "actual_name": "test_msg_buttons_template",
+                "template": "Hello",
+                "category": "TRANSACTIONAL",
+                "language": frappe.db.get_value("Language", {"language_code": "en"}) or "en",
+                "language_code": "en",
+                "whatsapp_account": "Test WA Msg Account",
+                "status": "APPROVED",
+                "id": "test_template_buttons_id",
+            })
+            tmpl.append("buttons", {
+                "button_type": "Quick Reply",
+                "button_label": "Yes",
+            })
+            tmpl.append("buttons", {
+                "button_type": "Call Phone",
+                "button_label": "Call Us",
+                "phone_number": "+919876543210",
+            })
+            tmpl.append("buttons", {
+                "button_type": "Visit Website",
+                "button_label": "Homepage",
+                "website_url": "https://example.com",
+                "url_type": "Static",
+            })
+            tmpl.flags.ignore_validate = True
+            tmpl.db_insert()
+            for row in tmpl.buttons:
+                row.db_insert()
+            frappe.db.commit()
+
+        doc = frappe.get_doc({
+            "doctype": "WhatsApp Message",
+            "type": "Outgoing",
+            "to": "919900112264",
+            "message_type": "Template",
+            "content_type": "text",
+            "template": template_name,
+            "whatsapp_account": "Test WA Msg Account",
+        })
+        doc.insert(ignore_permissions=True)
+
+        sent_data = json.loads(mock_post.call_args.kwargs["data"])
+        components = sent_data["template"]["components"]
+        sub_types = [c.get("sub_type") for c in components if c.get("type") == "button"]
+        self.assertNotIn("phone_number", sub_types)
+        self.assertNotIn("url", sub_types)  # static URL button also excluded
+        self.assertIn("quick_reply", sub_types)

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.py
@@ -306,6 +306,11 @@ class WhatsAppMessage(Document):
                 frappe.log_error(f"Failed to parse Product Catalog JSON: {str(e)}", "WhatsApp MPM Error")
 
         if template.buttons:
+            # Only buttons with *runtime* parameters go into components.
+            # Static Call Phone and static Visit Website buttons are applied
+            # by Meta from the approved template — sending them here yields
+            # "sub_type must be one of {...}" errors since Meta no longer
+            # accepts `phone_number`. See issue #188.
             button_parameters = []
             for idx, btn in enumerate(template.buttons):
                 # Shift index if MPM was added at index 0
@@ -318,18 +323,9 @@ class WhatsAppMessage(Document):
                         "index": current_idx,
                         "parameters": [{"type": "payload", "payload": btn.button_label}]
                     })
-                elif btn.button_type == "Call Phone":
-                    button_parameters.append({
-                        "type": "button",
-                        "sub_type": "phone_number",
-                        "index": current_idx,
-                        "parameters": [{"type": "text", "text": btn.phone_number}]
-                    })
-                elif btn.button_type == "Visit Website":
-                    url = btn.website_url
-                    if btn.url_type == "Dynamic":
-                        ref_doc = frappe.get_doc(self.reference_doctype, self.reference_name)
-                        url = ref_doc.get_formatted(btn.website_url)
+                elif btn.button_type == "Visit Website" and btn.url_type == "Dynamic":
+                    ref_doc = frappe.get_doc(self.reference_doctype, self.reference_name)
+                    url = ref_doc.get_formatted(btn.website_url)
                     button_parameters.append({
                         "type": "button",
                         "sub_type": "url",


### PR DESCRIPTION
Meta removed phone_number from the allowed button sub_types and applies static buttons from the approved template automatically — sending them in the components array now yields "sub_type must be one of {...}". Only emit button components for runtime-parameterized buttons (Quick Reply, Visit Website + url_type=Dynamic), matching the existing behavior in WhatsAppNotification.send_template_message.

Fixes: https://github.com/shridarpatil/frappe_whatsapp/issues/188