### PR TITLE
chore: silence Semgrep correctness check false positives

### DIFF
--- a/frappe_whatsapp/frappe_whatsapp/doctype/bulk_whatsapp_message/test_bulk_whatsapp_message.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/bulk_whatsapp_message/test_bulk_whatsapp_message.py
@@ -36,7 +36,7 @@ class TestBulkWhatsAppMessage(IntegrationTestCase):
             account.insert(ignore_permissions=True)
             from frappe.utils.password import set_encrypted_password
             set_encrypted_password("WhatsApp Account", account.name, "test_bulk_token", "token")
-            frappe.db.commit()
+            frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
     @classmethod
     def _ensure_test_template(cls):
@@ -56,7 +56,7 @@ class TestBulkWhatsAppMessage(IntegrationTestCase):
                 "id": "test_bulk_template_id",
             })
             doc.db_insert()
-            frappe.db.commit()
+            frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
     def setUp(self):
         # Set password within each test's transaction scope
@@ -73,7 +73,7 @@ class TestBulkWhatsAppMessage(IntegrationTestCase):
         for name in frappe.get_all("Bulk WhatsApp Message", filters={"title": ["like", "Test Bulk%"]}, pluck="name"):
             frappe.db.set_value("Bulk WhatsApp Message", name, "docstatus", 2)
             frappe.delete_doc("Bulk WhatsApp Message", name, force=True)
-        frappe.db.commit()
+        frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
     def _make_bulk_message(self, **kwargs):
         """Helper to create a Bulk WhatsApp Message."""
@@ -185,7 +185,7 @@ class TestBulkWhatsAppMessage(IntegrationTestCase):
         })
         failed_msg.flags.ignore_validate = True
         failed_msg.db_insert()
-        frappe.db.commit()
+        frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
         with patch(
             "frappe_whatsapp.frappe_whatsapp.doctype.bulk_whatsapp_message.bulk_whatsapp_message.frappe.enqueue_doc"
@@ -217,7 +217,7 @@ class TestBulkWhatsAppMessage(IntegrationTestCase):
         })
         failed_msg.flags.ignore_validate = True
         failed_msg.db_insert()
-        frappe.db.commit()
+        frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
         doc.resend_single_message(failed_msg.name)
 

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_account/test_whatsapp_account.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_account/test_whatsapp_account.py
@@ -15,12 +15,12 @@ class TestWhatsAppAccount(IntegrationTestCase):
         # Clear ALL defaults to prevent cascading on_update side effects
         # (other test classes' accounts would trigger there_must_be_only_one_default)
         frappe.db.sql("UPDATE `tabWhatsApp Account` SET is_default_incoming=0, is_default_outgoing=0")
-        frappe.db.commit()
+        frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
     def tearDown(self):
         for name in frappe.get_all("WhatsApp Account", filters={"account_name": ["like", "Test WA Account%"]}, pluck="name"):
             frappe.delete_doc("WhatsApp Account", name, force=True)
-        frappe.db.commit()
+        frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
     def _make_account(self, account_name="Test WA Account 1", **kwargs):
         """Helper to create a WhatsApp Account."""

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/test_whatsapp_message.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/test_whatsapp_message.py
@@ -34,7 +34,7 @@ class TestWhatsAppMessage(IntegrationTestCase):
                 "is_default_outgoing": 1,
             })
             account.insert(ignore_permissions=True)
-            frappe.db.commit()
+            frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
     def setUp(self):
         # Set password within each test's transaction scope
@@ -54,7 +54,7 @@ class TestWhatsAppMessage(IntegrationTestCase):
             frappe.delete_doc("WhatsApp Message", name, force=True)
         for name in frappe.get_all("WhatsApp Profiles", filters={"number": ["like", "9199%"]}, pluck="name"):
             frappe.delete_doc("WhatsApp Profiles", name, force=True)
-        frappe.db.commit()
+        frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
     def test_incoming_message_creation(self):
         """Test creating an incoming WhatsApp message."""
@@ -322,7 +322,7 @@ class TestWhatsAppMessage(IntegrationTestCase):
                 "status": "APPROVED",
                 "id": "test_template_id_123",
             }).db_insert()
-            frappe.db.commit()
+            frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
         from frappe_whatsapp.frappe_whatsapp.doctype.whatsapp_message.whatsapp_message import send_template
         send_template(
@@ -388,7 +388,7 @@ class TestWhatsAppMessage(IntegrationTestCase):
                     **data,
                 })
                 row.db_insert()
-            frappe.db.commit()
+            frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
         doc = frappe.get_doc({
             "doctype": "WhatsApp Message",

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/test_whatsapp_notification.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/test_whatsapp_notification.py
@@ -34,7 +34,7 @@ class TestWhatsAppNotification(IntegrationTestCase):
                 "is_default_outgoing": 1,
             })
             account.insert(ignore_permissions=True)
-            frappe.db.commit()
+            frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
     @classmethod
     def _ensure_test_template(cls):
@@ -55,7 +55,7 @@ class TestWhatsAppNotification(IntegrationTestCase):
                 "header_type": "",
             })
             doc.db_insert()
-            frappe.db.commit()
+            frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
     def setUp(self):
         # Set password within each test's transaction scope
@@ -71,7 +71,7 @@ class TestWhatsAppNotification(IntegrationTestCase):
     def tearDown(self):
         for name in frappe.get_all("WhatsApp Notification", filters={"notification_name": ["like", "Test Notif%"]}, pluck="name"):
             frappe.delete_doc("WhatsApp Notification", name, force=True)
-        frappe.db.commit()
+        frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
     def _make_notification(self, **kwargs):
         doc = frappe.get_doc({

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification_log/test_whatsapp_notification_log.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification_log/test_whatsapp_notification_log.py
@@ -11,7 +11,7 @@ class TestWhatsAppNotificationLog(IntegrationTestCase):
     def tearDown(self):
         for name in frappe.get_all("WhatsApp Notification Log", filters={"template": ["like", "Test Log%"]}, pluck="name"):
             frappe.delete_doc("WhatsApp Notification Log", name, force=True)
-        frappe.db.commit()
+        frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
     def test_log_creation(self):
         """Test basic notification log creation."""

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_profiles/test_whatsapp_profiles.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_profiles/test_whatsapp_profiles.py
@@ -12,12 +12,12 @@ class TestWhatsAppProfiles(IntegrationTestCase):
         # Clean up leftover profiles from other test classes (e.g., notification tests)
         for name in frappe.get_all("WhatsApp Profiles", filters={"number": ["like", "9199%"]}, pluck="name"):
             frappe.delete_doc("WhatsApp Profiles", name, force=True)
-        frappe.db.commit()
+        frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
     def tearDown(self):
         for name in frappe.get_all("WhatsApp Profiles", filters={"number": ["like", "9199%"]}, pluck="name"):
             frappe.delete_doc("WhatsApp Profiles", name, force=True)
-        frappe.db.commit()
+        frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
     def _make_profile(self, **kwargs):
         """Helper to create a WhatsApp Profile."""

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_profiles/whatsapp_profiles.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_profiles/whatsapp_profiles.py
@@ -15,4 +15,4 @@ class WhatsAppProfiles(Document):
             self.number = format_number(self.number)
 
     def set_title(self):
-        self.title = " - ".join(filter(None, [self.profile_name, self.number])) or "Unnamed Profile"
+        self.title = " - ".join(p for p in (self.profile_name, self.number) if p) or "Unnamed Profile"

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_recipient_list/test_whatsapp_recipient_list.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_recipient_list/test_whatsapp_recipient_list.py
@@ -20,12 +20,12 @@ class TestWhatsAppRecipientList(IntegrationTestCase):
         """Ensure there's at least one user with mobile_no set for import tests."""
         if not frappe.db.get_value("User", "Administrator", "mobile_no"):
             frappe.db.set_value("User", "Administrator", "mobile_no", "919900000001")
-            frappe.db.commit()
+            frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
     def tearDown(self):
         for name in frappe.get_all("WhatsApp Recipient List", filters={"list_name": ["like", "Test Recipient%"]}, pluck="name"):
             frappe.delete_doc("WhatsApp Recipient List", name, force=True)
-        frappe.db.commit()
+        frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
     def _make_recipient_list(self, list_name="Test Recipient List 1", recipients=None):
         """Helper to create a WhatsApp Recipient List."""

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_templates/test_whatsapp_templates.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_templates/test_whatsapp_templates.py
@@ -33,7 +33,7 @@ class TestWhatsAppTemplates(IntegrationTestCase):
                 "is_default_outgoing": 1,
             })
             account.insert(ignore_permissions=True)
-            frappe.db.commit()
+            frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
     def setUp(self):
         # Set password within each test's transaction scope
@@ -50,7 +50,7 @@ class TestWhatsAppTemplates(IntegrationTestCase):
         # Use SQL-level delete to avoid triggering on_trash (which calls get_settings)
         frappe.db.delete("WhatsApp Templates", {"template_name": ["like", "test_tmpl_%"]})
         frappe.db.delete("WhatsApp Templates", {"template_name": ["like", "test_msg_template%"]})
-        frappe.db.commit()
+        frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
     def _make_template_without_hooks(self, **kwargs):
         """Create a template directly in DB to avoid Meta API calls."""
@@ -73,7 +73,7 @@ class TestWhatsAppTemplates(IntegrationTestCase):
             "sample_values": kwargs.get("sample_values", ""),
         })
         doc.db_insert()
-        frappe.db.commit()
+        frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
         return frappe.get_doc("WhatsApp Templates", doc.name)
 
     def test_template_autoname(self):

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_templates/whatsapp_templates.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_templates/whatsapp_templates.py
@@ -132,8 +132,10 @@ class WhatsAppTemplates(Document):
 
 
     def after_insert(self):
+        # actual_name / id / status are persisted via self.db_update() below
+        # after the Meta round-trip; the static check can't trace that call.
         if self.template_name:
-            self.actual_name = self.template_name.lower().replace(" ", "_")
+            self.actual_name = self.template_name.lower().replace(" ", "_")  # nosemgrep: frappe-modifying-but-not-committing
 
         self.get_settings()
         data = {
@@ -189,8 +191,8 @@ class WhatsAppTemplates(Document):
                 headers=self._headers,
                 data=json.dumps(data),
             )
-            self.id = response["id"]
-            self.status = response["status"]
+            self.id = response["id"]  # nosemgrep: frappe-modifying-but-not-committing
+            self.status = response["status"]  # nosemgrep: frappe-modifying-but-not-committing
             self.db_update()
         except Exception as e:
             res = frappe.flags.integration_request.json().get("error", {})
@@ -258,14 +260,17 @@ class WhatsAppTemplates(Document):
 
     def get_settings(self):
         """Get whatsapp settings."""
+        # Underscore-prefixed attributes below are in-memory scratch for the
+        # outbound HTTP call — they are not DocType fields and must not be
+        # persisted. Semgrep's static check can't tell the difference.
         settings = frappe.get_doc("WhatsApp Account", self.whatsapp_account)
-        self._token = settings.get_password("token")
-        self._url = settings.url
-        self._version = settings.version
-        self._business_id = settings.business_id
-        self._app_id = settings.app_id
+        self._token = settings.get_password("token")  # nosemgrep: frappe-modifying-but-not-committing-other-method
+        self._url = settings.url  # nosemgrep: frappe-modifying-but-not-committing-other-method
+        self._version = settings.version  # nosemgrep: frappe-modifying-but-not-committing-other-method
+        self._business_id = settings.business_id  # nosemgrep: frappe-modifying-but-not-committing-other-method
+        self._app_id = settings.app_id  # nosemgrep: frappe-modifying-but-not-committing-other-method
 
-        self._headers = {
+        self._headers = {  # nosemgrep: frappe-modifying-but-not-committing-other-method
             "authorization": f"Bearer {self._token}",
             "content-type": "application/json",
         }

--- a/frappe_whatsapp/utils/__init__.py
+++ b/frappe_whatsapp/utils/__init__.py
@@ -62,6 +62,7 @@ def _send_whatsapp_notification(notification_name, doctype, docname, commit=Fals
             notification_name
         ).send_template_message(doc)
         if commit:
+            # nosemgrep: frappe-manual-commit -- runs in after_commit callback outside request scope; WhatsApp Message + Notification Log rows rely on this to persist
             frappe.db.commit()
     except Exception:
         if commit:

--- a/frappe_whatsapp/utils/test_bulk_messaging.py
+++ b/frappe_whatsapp/utils/test_bulk_messaging.py
@@ -42,7 +42,7 @@ class TestBulkMessagingUtils(IntegrationTestCase):
                 "is_default_outgoing": 1,
             })
             account.insert(ignore_permissions=True)
-            frappe.db.commit()
+            frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
     @classmethod
     def _ensure_test_template(cls):
@@ -62,14 +62,14 @@ class TestBulkMessagingUtils(IntegrationTestCase):
                 "id": "test_bulkutil_template_id",
             })
             doc.db_insert()
-            frappe.db.commit()
+            frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
     @classmethod
     def _ensure_test_user_with_mobile(cls):
         """Ensure there's at least one user with mobile_no set for import tests."""
         if not frappe.db.get_value("User", "Administrator", "mobile_no"):
             frappe.db.set_value("User", "Administrator", "mobile_no", "919900000001")
-            frappe.db.commit()
+            frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
     def setUp(self):
         # Set password within each test's transaction scope
@@ -88,7 +88,7 @@ class TestBulkMessagingUtils(IntegrationTestCase):
             frappe.delete_doc("Bulk WhatsApp Message", name, force=True)
         for name in frappe.get_all("WhatsApp Recipient List", filters={"list_name": ["like", "Test BulkUtil%"]}, pluck="name"):
             frappe.delete_doc("WhatsApp Recipient List", name, force=True)
-        frappe.db.commit()
+        frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
     def _make_bulk_message(self, title="Test BulkUtil Msg"):
         """Create a bulk message for testing."""
@@ -134,7 +134,7 @@ class TestBulkMessagingUtils(IntegrationTestCase):
         })
         failed_msg.flags.ignore_validate = True
         failed_msg.db_insert()
-        frappe.db.commit()
+        frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
         result = retry_failed(doc.name)
         self.assertTrue(result)

--- a/frappe_whatsapp/utils/test_utils.py
+++ b/frappe_whatsapp/utils/test_utils.py
@@ -53,7 +53,7 @@ class TestGetWhatsAppAccount(IntegrationTestCase):
                 "is_default_outgoing": 1,
             })
             account.insert(ignore_permissions=True)
-            frappe.db.commit()
+            frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
     def setUp(self):
         # Clear ALL defaults then set ours (db.set_value bypasses on_update hooks)
@@ -113,7 +113,7 @@ class TestGetNotificationsMap(IntegrationTestCase):
                 "webhook_verify_token": "utils_map_verify_token",
             })
             account.insert(ignore_permissions=True)
-            frappe.db.commit()
+            frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
         template_name = "test_utils_map_template-en"
         if not frappe.db.exists("WhatsApp Templates", template_name):
@@ -130,7 +130,7 @@ class TestGetNotificationsMap(IntegrationTestCase):
                 "id": "test_utils_map_tmpl_id",
             })
             doc.db_insert()
-            frappe.db.commit()
+            frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
         if not frappe.db.exists("WhatsApp Notification", "Test Utils Map Notif"):
             frappe.get_doc({
@@ -143,7 +143,7 @@ class TestGetNotificationsMap(IntegrationTestCase):
                 "template": template_name,
                 "disabled": 0,
             }).insert(ignore_permissions=True)
-            frappe.db.commit()
+            frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
         result = get_notifications_map()
         self.assertIn("User", result)

--- a/frappe_whatsapp/utils/test_webhook.py
+++ b/frappe_whatsapp/utils/test_webhook.py
@@ -41,7 +41,7 @@ class TestWebhookHelpers(IntegrationTestCase):
             account.insert(ignore_permissions=True)
             from frappe.utils.password import set_encrypted_password
             set_encrypted_password("WhatsApp Account", account.name, "test_webhook_token", "token")
-            frappe.db.commit()
+            frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
     def setUp(self):
         # Set password within each test's transaction scope
@@ -53,7 +53,7 @@ class TestWebhookHelpers(IntegrationTestCase):
             frappe.delete_doc("WhatsApp Message", name, force=True)
         for name in frappe.get_all("WhatsApp Notification Log", filters={"template": "Webhook"}, pluck="name"):
             frappe.delete_doc("WhatsApp Notification Log", name, force=True)
-        frappe.db.commit()
+        frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
     def test_update_status_template_status(self):
         """Test update_status routes to template status update."""
@@ -81,7 +81,7 @@ class TestWebhookHelpers(IntegrationTestCase):
         })
         msg.flags.ignore_validate = True
         msg.db_insert()
-        frappe.db.commit()
+        frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
         data = {
             "statuses": [{
@@ -109,7 +109,7 @@ class TestWebhookHelpers(IntegrationTestCase):
         })
         msg.flags.ignore_validate = True
         msg.db_insert()
-        frappe.db.commit()
+        frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
         data = {
             "statuses": [{
@@ -140,7 +140,7 @@ class TestWebhookHelpers(IntegrationTestCase):
                 "id": "webhook_tmpl_id_123",
             })
             doc.db_insert()
-            frappe.db.commit()
+            frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
         data = {
             "event": "APPROVED",
@@ -175,7 +175,7 @@ class TestWebhookEndpoint(IntegrationTestCase):
             account.insert(ignore_permissions=True)
             from frappe.utils.password import set_encrypted_password
             set_encrypted_password("WhatsApp Account", account.name, "ep_token", "token")
-            frappe.db.commit()
+            frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
     def setUp(self):
         # Set password within each test's transaction scope
@@ -195,7 +195,7 @@ class TestWebhookEndpoint(IntegrationTestCase):
             frappe.delete_doc("WhatsApp Notification Log", name, force=True)
         for name in frappe.get_all("WhatsApp Profiles", filters={"number": ["like", "9199%"]}, pluck="name"):
             frappe.delete_doc("WhatsApp Profiles", name, force=True)
-        frappe.db.commit()
+        frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
     def _make_mock_request(self, method="GET"):
         """Create a mock request object."""
@@ -371,7 +371,7 @@ class TestWebhookEndpoint(IntegrationTestCase):
         })
         msg.flags.ignore_validate = True
         msg.db_insert()
-        frappe.db.commit()
+        frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
 
         mock_request = self._make_mock_request("POST")
         payload = {


### PR DESCRIPTION
Annotate intentional patterns that Semgrep flags as violations:

- Test-fixture frappe.db.commit() calls: required so setUpClass / helpers persist data for subsequent queries and mocks.
- utils.__init__._send_whatsapp_notification commit: runs inside a Frappe v16 after_commit callback, outside the request auto-commit scope, so the Message + Notification Log inserts rely on it.
- whatsapp_templates.get_settings: self._* attributes are in-memory scratch for the outbound Meta HTTP call, not DocType fields.
- whatsapp_templates.after_insert: self.actual_name / id / status are persisted via self.db_update() after the Meta round-trip.

Also rewrite whatsapp_profiles.set_title to use a generator expression instead of filter() per frappe-no-functional-code.