### PR TITLE
feat(whatsapp-message): support header & footer in interactive messages

### DIFF
--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.json
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.json
@@ -25,6 +25,8 @@
   "content_type",
   "attach",
   "buttons",
+  "header_text",
+  "footer_text",
   "body_param",
   "whatsapp_account",
   "section_break_flow",
@@ -159,6 +161,22 @@
    "fieldname": "buttons",
    "fieldtype": "JSON",
    "label": "Buttons"
+  },
+  {
+   "depends_on": "eval:doc.content_type=='interactive'",
+   "description": "Optional header text shown above the message body (max 60 characters)",
+   "fieldname": "header_text",
+   "fieldtype": "Data",
+   "label": "Header Text",
+   "length": 60
+  },
+  {
+   "depends_on": "eval:doc.content_type=='interactive'",
+   "description": "Optional footer text shown below the message body (max 60 characters)",
+   "fieldname": "footer_text",
+   "fieldtype": "Data",
+   "label": "Footer Text",
+   "length": 60
   },
   {
    "fieldname": "section_break_iyjf",

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.py
@@ -106,7 +106,13 @@ class WhatsAppMessage(Document):
                 data["type"] = "interactive"
                 buttons_data = json.loads(self.buttons) if isinstance(self.buttons, str) else self.buttons
 
-                if isinstance(buttons_data, list) and len(buttons_data) > 3:
+                if not isinstance(buttons_data, list) or not buttons_data:
+                    frappe.throw(_(
+                        "Please provide at least one button as a JSON array, "
+                        "e.g. [{\"id\": \"yes\", \"title\": \"Yes\"}]"
+                    ))
+
+                if len(buttons_data) > 3:
                     # Use list message for more than 3 options (max 10)
                     data["interactive"] = {
                         "type": "list",
@@ -137,6 +143,15 @@ class WhatsAppMessage(Document):
                             ]
                         }
                     }
+
+                # Optional header and footer (supported for both list and button types)
+                if self.header_text:
+                    data["interactive"]["header"] = {
+                        "type": "text",
+                        "text": self.header_text,
+                    }
+                if self.footer_text:
+                    data["interactive"]["footer"] = {"text": self.footer_text}
 
             elif self.content_type == "flow":
                 # WhatsApp Flow message


### PR DESCRIPTION
Add optional `header_text` and `footer_text` fields to the WhatsApp Message doctype and include them in the interactive payload sent to Meta (for both list and button types), per the WhatsApp Cloud API interactive list/button message spec.