### PR TITLE
Automatically tag reference doctype and docname for replies

### DIFF
--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.js
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.js
@@ -12,8 +12,16 @@ frappe.ui.form.on('WhatsApp Message', {
 	refresh: function(frm) {
 		if (frm.doc.type == 'Incoming'){
 			frm.add_custom_button(__("Reply"), function(){
-				frappe.new_doc("WhatsApp Message", {"to": frm.doc.from});
-
+				let opts = {
+					"to": frm.doc.from,
+					"is_reply": 1,
+					"reply_to_message_id": frm.doc.message_id,
+				};
+				if (frm.doc.reference_doctype && frm.doc.reference_name) {
+					opts["reference_doctype"] = frm.doc.reference_doctype;
+					opts["reference_name"] = frm.doc.reference_name;
+				}
+				frappe.new_doc("WhatsApp Message", opts);
 			});
 		}
 

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.py
@@ -50,10 +50,29 @@ class WhatsAppMessage(Document):
             else:
                 self.whatsapp_account = default_whatsapp_account.name
 
+    def copy_reference_from_reply(self):
+        """Copy reference_doctype/reference_name from the original incoming message when replying."""
+        if (
+            self.type == "Outgoing"
+            and self.is_reply
+            and self.reply_to_message_id
+            and not self.reference_doctype
+        ):
+            ref = frappe.db.get_value(
+                "WhatsApp Message",
+                {"message_id": self.reply_to_message_id},
+                ["reference_doctype", "reference_name"],
+                as_dict=True,
+            )
+            if ref and ref.reference_doctype and ref.reference_name:
+                self.reference_doctype = ref.reference_doctype
+                self.reference_name = ref.reference_name
+
     """Send whats app messages."""
     def before_insert(self):
         """Send message."""
         self.set_whatsapp_account()
+        self.copy_reference_from_reply()
         # Route to template path when a template is selected,
         # since message_type is read_only and cannot be set from the UI.
         if self.template:


### PR DESCRIPTION
Copy reference_doctype and reference_name to outgoing reply messages

When replying to an incoming WhatsApp message that has reference_doctype and reference_name set, these fields are now carried over to the outgoing reply — both from the UI (Reply button) and programmatically via before_insert.