### PR TITLE
fix: Allow framework-managed columns (name, creation, etc.) in data_fields

### DIFF
--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_recipient_list/test_whatsapp_recipient_list.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_recipient_list/test_whatsapp_recipient_list.py
@@ -108,6 +108,30 @@ class TestWhatsAppRecipientList(IntegrationTestCase):
                 data = json.loads(recipient.recipient_data)
                 self.assertIsInstance(data, dict)
 
+    def test_import_list_with_default_field_name(self):
+        """Test importing with 'name' (a framework default_field) in data_fields."""
+        doc = self._make_recipient_list(
+            list_name="Test Recipient DefaultField",
+            recipients=[{"mobile_number": "placeholder"}]
+        )
+
+        count = doc.import_list_from_doctype(
+            doctype="User",
+            mobile_field="mobile_no",
+            name_field="full_name",
+            data_fields=["name"],
+            filters={"mobile_no": ["is", "set"]},
+            limit=3,
+        )
+
+        self.assertGreater(count, 0)
+        doc.save()
+        for recipient in doc.recipients:
+            data = json.loads(recipient.recipient_data)
+            self.assertIn("name", data)
+            self.assertTrue(data["name"])
+            self.assertTrue(frappe.db.exists("User", data["name"]))
+
     def test_import_clears_existing_recipients(self):
         """Test that import replaces existing recipients."""
         doc = self._make_recipient_list(

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_recipient_list/whatsapp_recipient_list.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_recipient_list/whatsapp_recipient_list.py
@@ -28,11 +28,14 @@ class WhatsAppRecipientList(Document):
 		if name_field:
 			fields.append(name_field)
 		if data_fields:
+			from frappe.model import default_fields
 			meta = frappe.get_meta(doctype)
-			# print(meta.fields)
-			for field in meta.fields:
-				if field.fieldname not in fields and field.fieldname in data_fields:
-					fields.append(field.fieldname)
+			meta_fieldnames = {f.fieldname for f in meta.fields}
+			for field in data_fields:
+				if field in fields:
+					continue
+				if field in meta_fieldnames or field in default_fields:
+					fields.append(field)
 		# Get records from the doctype
 		records = frappe.get_all(
 			doctype,

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_recipient_list/whatsapp_recipient_list.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_recipient_list/whatsapp_recipient_list.py
@@ -1,6 +1,7 @@
 import frappe
 import json
 from frappe import _
+from frappe.model import default_fields
 from frappe.model.document import Document
 
 
@@ -28,13 +29,10 @@ class WhatsAppRecipientList(Document):
 		if name_field:
 			fields.append(name_field)
 		if data_fields:
-			from frappe.model import default_fields
 			meta = frappe.get_meta(doctype)
 			meta_fieldnames = {f.fieldname for f in meta.fields}
 			for field in data_fields:
-				if field in fields:
-					continue
-				if field in meta_fieldnames or field in default_fields:
+				if field not in fields and (field in meta_fieldnames or field in default_fields):
 					fields.append(field)
 		# Get records from the doctype
 		records = frappe.get_all(


### PR DESCRIPTION
Closes #229

`import_list_from_doctype` validated `data_fields` against `meta.fields`, which only enumerates user-declared DocFields. Framework-managed columns from `frappe.model.default_fields` (`name`, `creation`, `modified`, `modified_by`, `owner`, `docstatus`, `idx`) were silently dropped, so passing e.g. `data_fields=["name"]` produced empty `recipient_data` with no error. See #229 for the full repro.

**Fix:** Inverted the validation loop to iterate `data_fields` directly and accept any fieldname present in either `meta.fields` or `frappe.model.default_fields`. This is purely additive — strictly more `data_fields` inputs are now accepted; no existing behavior changes.

**Test:** Added `test_import_list_with_default_field_name` which imports with `data_fields=["name"]` and asserts each recipient's `recipient_data` contains a truthy `name` key pointing to a real `User` record.

**Risk:** Minimal. The change only widens the set of accepted field names. Callers that were already passing valid user-declared fields see no difference.