### PR TITLE
fix(webhook): do not drop message_template_status_update events

### DIFF
--- a/frappe_whatsapp/utils/test_webhook.py
+++ b/frappe_whatsapp/utils/test_webhook.py
@@ -399,6 +399,59 @@ class TestWebhookEndpoint(IntegrationTestCase):
         self.assertEqual(msg.status, "read")
         self.assertEqual(msg.conversation_id, "conv_456")
 
+    def test_webhook_post_template_status_update(self):
+        """Template status updates have no metadata.phone_number_id; the handler
+        must still route them to update_status. Regression for PR #231."""
+        template_id = "webhook_ep_tmpl_id_status"
+        template_name = "ep_status_template-en"
+
+        # Seed the template (or reset its status if a prior run left it APPROVED)
+        if frappe.db.exists("WhatsApp Templates", template_name):
+            frappe.db.set_value(
+                "WhatsApp Templates", template_name, "status", "PENDING"
+            )
+        else:
+            doc = frappe.get_doc({
+                "doctype": "WhatsApp Templates",
+                "template_name": "ep_status_template",
+                "actual_name": "ep_status_template",
+                "template": "Status webhook regression template",
+                "category": "TRANSACTIONAL",
+                "language": frappe.db.get_value("Language", {"language_code": "en"}) or "en",
+                "language_code": "en",
+                "whatsapp_account": "Test WA Webhook EP Account",
+                "status": "PENDING",
+                "id": template_id,
+            })
+            doc.db_insert()
+        frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
+
+        mock_request = self._make_mock_request("POST")
+        payload = {
+            "entry": [{
+                "changes": [{
+                    "field": "message_template_status_update",
+                    "value": {
+                        "event": "APPROVED",
+                        "message_template_id": template_id,
+                        "message_template_name": "ep_status_template",
+                        "message_template_language": "en_US",
+                        "reason": None,
+                    },
+                }],
+            }],
+        }
+        frappe.local.form_dict = frappe._dict(payload)
+
+        with patch("frappe_whatsapp.utils.webhook.frappe.request", mock_request):
+            from frappe_whatsapp.utils.webhook import webhook
+            webhook()
+
+        status = frappe.db.get_value(
+            "WhatsApp Templates", {"id": template_id}, "status"
+        )
+        self.assertEqual(status, "APPROVED")
+
     def test_webhook_creates_notification_log(self):
         """Test that webhook POST creates a notification log entry."""
         mock_request = self._make_mock_request("POST")

--- a/frappe_whatsapp/utils/webhook.py
+++ b/frappe_whatsapp/utils/webhook.py
@@ -62,7 +62,14 @@ def post():
 	)
 
 	whatsapp_account = get_whatsapp_account(phone_id) if phone_id else None
-	if not whatsapp_account:
+
+	# Only `messages` events carry `metadata.phone_number_id`. Status-change
+	# events (`message_template_status_update`, message status callbacks) have
+	# no metadata, so `phone_id` is None and `whatsapp_account` is also None
+	# for them by design. Gating the entire handler on `whatsapp_account`
+	# silently drops every template-status update; gate only the message-
+	# ingestion branch instead.
+	if messages and not whatsapp_account:
 		return
 
 	if messages:


### PR DESCRIPTION
The webhook `post()` handler extracted `phone_number_id` from `value.metadata`, which only exists on `messages` events. For `message_template_status_update` events (and message status callbacks), that field is absent, so `phone_id` was `None` and `get_whatsapp_account` returned `None`.

The previous `if not whatsapp_account: return` then aborted the entire handler — silently dropping every template approval/rejection webhook. The Notification Log was still written (it happens earlier), but `update_status()` was never invoked, so `tabWhatsApp Templates.status` never updated unless the user manually ran "Sync from Meta".

Gate only the message-ingestion branch on `whatsapp_account` so the status-update branch is reached for events that have no metadata.

Reproduction:
1. Submit a new WhatsApp Template via the Desk DocType.
2. Wait for Meta to approve (or reject) it.
3. Observe in Meta App Dashboard that the status webhook was delivered.
4. Note `tabWhatsApp Notification Log` contains the payload with `event=APPROVED` and `field=message_template_status_update`.
5. Note `tabWhatsApp Templates.status` is still `PENDING`.

After this fix, the handler reaches `update_status()` for those events and the `UPDATE` in `update_template_status()` runs as intended.