### PR TITLE
fix: honor scheduled_time in bulk WhatsApp messages

### DIFF
--- a/frappe_whatsapp/frappe_whatsapp/doctype/bulk_whatsapp_message/bulk_whatsapp_message.js
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/bulk_whatsapp_message/bulk_whatsapp_message.js
@@ -1,5 +1,13 @@
 frappe.ui.form.on('Bulk WhatsApp Message', {
     refresh: function(frm) {
+        if(frm.doc.docstatus === 1 && frm.doc.status === 'Scheduled') {
+            frm.dashboard.set_headline(
+                __('This message is scheduled to be sent on {0}',
+                    [frappe.datetime.str_to_user(frm.doc.scheduled_time)]),
+                'blue'
+            );
+        }
+
         // Add progress bar
         if(frm.doc.docstatus === 1 && frm.doc.status != 'Draft') {
             frm.add_custom_button(__('Check Progress'), function() {
@@ -56,6 +64,11 @@ frappe.ui.form.on('Bulk WhatsApp Message', {
         }
     },
     validate: function(frm) {
+        if(frm.doc.scheduled_time && new Date(frm.doc.scheduled_time) <= new Date()) {
+            frappe.throw(__('Scheduled time must be in the future'));
+            return false;
+        }
+
         if(frm.doc.recipient_type == 'Individual' && (!frm.doc.recipients || frm.doc.recipients.length === 0)) {
             frappe.throw(__('Please add at least one recipient'));
             return false;

--- a/frappe_whatsapp/frappe_whatsapp/doctype/bulk_whatsapp_message/bulk_whatsapp_message.json
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/bulk_whatsapp_message/bulk_whatsapp_message.json
@@ -118,7 +118,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Status",
-   "options": "Draft\nQueued\nIn Progress\nCompleted\nPartially Failed",
+   "options": "Draft\nScheduled\nQueued\nIn Progress\nCompleted\nPartially Failed",
    "read_only": 1
   },
   {

--- a/frappe_whatsapp/frappe_whatsapp/doctype/bulk_whatsapp_message/bulk_whatsapp_message.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/bulk_whatsapp_message/bulk_whatsapp_message.py
@@ -21,6 +21,11 @@ class BulkWhatsAppMessage(Document):
     def validate(self):
         # self.validate_message()
         self.validate_recipients()
+        self.validate_scheduled_time()
+
+    def validate_scheduled_time(self):
+        if self.scheduled_time and get_datetime(self.scheduled_time) <= get_datetime(now()):
+            frappe.throw(_("Scheduled time must be in the future"))
     
     def validate_message(self):
         if not self.message_content:
@@ -41,8 +46,11 @@ class BulkWhatsAppMessage(Document):
             self.recipient_count = len(self.recipients)
     
     def on_submit(self):
-        self.db_set("status", "Queued")
-        self.queue_messages()
+        if self.scheduled_time and get_datetime(self.scheduled_time) > get_datetime(now()):
+            self.db_set("status", "Scheduled")
+        else:
+            self.db_set("status", "Queued")
+            self.queue_messages()
     
     def queue_messages(self):
         """Queue messages for sending"""

--- a/frappe_whatsapp/hooks.py
+++ b/frappe_whatsapp/hooks.py
@@ -116,7 +116,8 @@ app_include_js = "/assets/frappe_whatsapp/js/frappe_whatsapp.js"
 
 scheduler_events = {
     "all": [
-        "frappe_whatsapp.utils.trigger_whatsapp_notifications_all"
+        "frappe_whatsapp.utils.trigger_whatsapp_notifications_all",
+        "frappe_whatsapp.utils.bulk_messaging.process_scheduled_bulk_messages"
     ],
     "hourly": [
         "frappe_whatsapp.utils.trigger_whatsapp_notifications_hourly"

--- a/frappe_whatsapp/utils/bulk_messaging.py
+++ b/frappe_whatsapp/utils/bulk_messaging.py
@@ -44,12 +44,26 @@ def process_scheduled_bulk_messages():
     )
 
     for name in scheduled:
-        doc = frappe.get_doc("Bulk WhatsApp Message", name)
-        doc.db_set("status", "Queued")
-        doc.queue_messages()
-
-    if scheduled:
+        # Claim the campaign before enqueuing anything. queue_messages() calls
+        # frappe.enqueue_doc, which pushes to redis immediately
+        # (enqueue_after_commit defaults to False), so the "Queued" flip has to
+        # be durable first: if it were still uncommitted when a later campaign
+        # raised, the rollback would revert this one to "Scheduled" while its
+        # recipient jobs were already queued, and the next tick would enqueue
+        # every recipient a second time.
+        frappe.db.set_value("Bulk WhatsApp Message", name, "status", "Queued")
+        # nosemgrep: frappe-manual-commit -- scheduler job outside request scope; the status must be durable before enqueue_doc hands the jobs to redis
         frappe.db.commit()
+
+        try:
+            frappe.get_doc("Bulk WhatsApp Message", name).queue_messages()
+        except Exception:
+            # Roll back so a DB-level failure doesn't poison the transaction for
+            # the remaining campaigns (and so log_error can write).
+            frappe.db.rollback()
+            frappe.log_error(
+                title=f"Bulk WhatsApp Message scheduling failed: {name}"
+            )
 
 
 @frappe.whitelist()

--- a/frappe_whatsapp/utils/bulk_messaging.py
+++ b/frappe_whatsapp/utils/bulk_messaging.py
@@ -1,6 +1,6 @@
 import json
 import frappe
-from frappe.utils import cint
+from frappe.utils import cint, now
 
 
 @frappe.whitelist()
@@ -30,6 +30,27 @@ def import_recipients(list_name, doctype, mobile_field, name_field=None, filters
     doc.save()
     
     return count
+
+def process_scheduled_bulk_messages():
+    """Check for scheduled bulk messages whose time has arrived and queue them."""
+    scheduled = frappe.get_all(
+        "Bulk WhatsApp Message",
+        filters={
+            "status": "Scheduled",
+            "docstatus": 1,
+            "scheduled_time": ["<=", now()],
+        },
+        pluck="name",
+    )
+
+    for name in scheduled:
+        doc = frappe.get_doc("Bulk WhatsApp Message", name)
+        doc.db_set("status", "Queued")
+        doc.queue_messages()
+
+    if scheduled:
+        frappe.db.commit()
+
 
 @frappe.whitelist()
 def schedule_bulk_messages():

--- a/frappe_whatsapp/utils/test_bulk_messaging.py
+++ b/frappe_whatsapp/utils/test_bulk_messaging.py
@@ -5,13 +5,20 @@ import json
 from unittest.mock import patch
 
 import frappe
+from frappe.utils import add_to_date, now
 from frappe_whatsapp.testing import IntegrationTestCase
 
 from frappe_whatsapp.utils.bulk_messaging import (
     get_progress,
     import_recipients,
+    process_scheduled_bulk_messages,
     retry_failed,
     schedule_bulk_messages,
+)
+
+QUEUE_MESSAGES = (
+    "frappe_whatsapp.frappe_whatsapp.doctype.bulk_whatsapp_message"
+    ".bulk_whatsapp_message.BulkWhatsAppMessage.queue_messages"
 )
 
 
@@ -182,3 +189,87 @@ class TestBulkMessagingUtils(IntegrationTestCase):
         # This just ensures the function runs without error
         # when there are no queued bulk messages
         schedule_bulk_messages()
+
+    def _make_due_scheduled_message(self, title):
+        """Submit a scheduled campaign and back-date it so it is due.
+
+        scheduled_time has to be in the future to pass validation, so the
+        back-dating goes through db.set_value to bypass the controller.
+        """
+        doc = self._make_bulk_message(title=title)
+        doc.db_set("scheduled_time", add_to_date(now(), hours=1))
+        doc.submit()
+        self.assertEqual(doc.status, "Scheduled")
+        frappe.db.set_value(
+            "Bulk WhatsApp Message", doc.name,
+            "scheduled_time", add_to_date(now(), hours=-1),
+        )
+        return doc
+
+    @patch(QUEUE_MESSAGES)
+    def test_scheduled_campaign_gets_queued(self, mock_queue):
+        """A due campaign is flipped to Queued and its recipients enqueued."""
+        doc = self._make_due_scheduled_message("Test BulkUtil Due")
+
+        process_scheduled_bulk_messages()
+
+        self.assertEqual(mock_queue.call_count, 1)
+        self.assertEqual(
+            frappe.db.get_value("Bulk WhatsApp Message", doc.name, "status"),
+            "Queued",
+        )
+
+    @patch(QUEUE_MESSAGES)
+    def test_one_failing_campaign_does_not_block_the_others(self, mock_queue):
+        """A campaign that raises while enqueuing must not abort the tick.
+
+        Pre-fix the exception propagated out of the loop, so every campaign
+        after the failing one was skipped and the whole transaction rolled
+        back — while the already-enqueued jobs still went out, which is what
+        produced duplicate sends on the following tick.
+        """
+        self._make_due_scheduled_message("Test BulkUtil Fail A")
+        second = self._make_due_scheduled_message("Test BulkUtil Fail B")
+
+        # raise on the first campaign only, succeed for the rest
+        calls = []
+
+        def _dispatch(*args, **kwargs):
+            calls.append(True)
+            if len(calls) == 1:
+                raise Exception("enqueue blew up")
+
+        mock_queue.side_effect = _dispatch
+
+        process_scheduled_bulk_messages()
+
+        self.assertEqual(len(calls), 2, "second campaign was never processed")
+        self.assertEqual(
+            frappe.db.get_value("Bulk WhatsApp Message", second.name, "status"),
+            "Queued",
+        )
+
+    @patch(QUEUE_MESSAGES)
+    def test_failed_campaign_stays_claimed_and_is_logged(self, mock_queue):
+        """A partially-enqueued campaign must not revert to Scheduled.
+
+        If it did, the next tick would re-select it and enqueue every
+        recipient again, double-sending to everyone already dispatched.
+        """
+        doc = self._make_due_scheduled_message("Test BulkUtil Claim")
+        mock_queue.side_effect = Exception("enqueue blew up")
+
+        process_scheduled_bulk_messages()
+
+        self.assertNotEqual(
+            frappe.db.get_value("Bulk WhatsApp Message", doc.name, "status"),
+            "Scheduled",
+        )
+        self.assertTrue(
+            frappe.get_all(
+                "Error Log",
+                filters={"error": ["like", f"%{doc.name}%"]},
+                limit=1,
+            ),
+            "failure was swallowed without an Error Log entry",
+        )


### PR DESCRIPTION
## Summary
- Fixes #233 — Bulk WhatsApp Messages now respect the `scheduled_time` field instead of sending immediately on submit
- If `scheduled_time` is set to a future datetime, status is set to **"Scheduled"** and a periodic scheduler job picks it up once the time arrives
- Added "Scheduled" to the status options and a blue info banner on the form showing when the message will be sent
- Added client-side and server-side validation to prevent setting a past scheduled time

## Test plan
- [ ] Create a Bulk WhatsApp Message with `scheduled_time` set to a few minutes in the future → status should be "Scheduled" with info banner
- [ ] Wait for the scheduled time to pass → scheduler should transition to "Queued" and messages get sent
- [ ] Create a Bulk WhatsApp Message without `scheduled_time` → should send immediately as before
- [ ] Try setting `scheduled_time` to a past datetime → should be rejected with validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)