### PR TITLE
Feat: SRO-2026-06-00187 - Whatsapp message log cleanup

### DIFF
--- a/frappe_whatsapp/frappe_whatsapp/doctype/bulk_whatsapp_message/bulk_whatsapp_message.json
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/bulk_whatsapp_message/bulk_whatsapp_message.json
@@ -16,7 +16,9 @@
   "section_message",
   "use_template",
   "template",
+  "variable_type",
   "template_variables",
+  "attach",
   "section_status",
   "status",
   "sent_count",
@@ -93,7 +95,6 @@
    "depends_on": "eval:doc.use_template==1",
    "fieldname": "template_variables",
    "fieldtype": "Code",
-   "hidden": 1,
    "label": "Template Variables",
    "options": "JSON"
   },
@@ -132,12 +133,26 @@
    "options": "Bulk WhatsApp Message",
    "print_hide": 1,
    "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.use_template==1",
+   "fieldname": "attach",
+   "fieldtype": "Attach",
+   "label": "Attach"
+  },
+  {
+   "default": "Common",
+   "depends_on": "eval:doc.use_template==1",
+   "fieldname": "variable_type",
+   "fieldtype": "Select",
+   "label": "Variable Type",
+   "options": "Common\nUnique"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-03-03 11:28:42.295568",
+ "modified": "2025-08-24 11:05:07.017547",
  "modified_by": "Administrator",
  "module": "Frappe Whatsapp",
  "name": "Bulk WhatsApp Message",
@@ -173,6 +188,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/frappe_whatsapp/frappe_whatsapp/doctype/bulk_whatsapp_message/bulk_whatsapp_message.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/bulk_whatsapp_message/bulk_whatsapp_message.py
@@ -100,8 +100,13 @@ class BulkWhatsAppMessage(Document):
             wa_message.message_type = 'Template'
             wa_message.use_template = self.use_template
             # Handle template variables if needed
-            if self.template_variables:
-                wa_message.template_variables = self.template_variables
+
+            if recipient.get("recipient_data") and self.variable_type=='Unique':
+                wa_message.body_param = recipient.get("recipient_data")
+            elif self.template_variables and self.variable_type=='Common':
+                wa_message.body_param = self.template_variables
+            if self.attach:
+                wa_message.attach = self.attach
         
         # Set status to queued
         wa_message.status = "Queued"

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/test_whatsapp_message.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/test_whatsapp_message.py
@@ -46,7 +46,7 @@ class TestApplyWhatsappMessageStatus(FrappeTestCase):
         _m_get, m_set, m_commit, m_rb, m_log = self._run(set_value_side_effect=se)
         self.assertEqual(m_set.call_count, 3, "set_value retried until it succeeds")
         self.assertEqual(m_commit.call_count, 1, "commit once, after the successful UPDATE")
-        self.assertEqual(m_rb.call_count, 2, "rollback before each of the 2 retries (fresh snapshot)")
+        self.assertEqual(m_rb.call_count, 3, "one up-front rollback + before each of the 2 retries (fresh snapshot)")
         m_log.assert_not_called()
 
     def test_exhaustion_logs_once_and_does_not_raise(self):
@@ -56,8 +56,12 @@ class TestApplyWhatsappMessageStatus(FrappeTestCase):
             raise frappe.QueryTimeoutError("1205 lock wait timeout")
 
         _m_get, m_set, m_commit, m_rb, m_log = self._run(set_value_side_effect=se)  # must not raise
-        self.assertEqual(m_set.call_count, 5, "exactly _STATUS_RETRY_ATTEMPTS attempts")
-        self.assertEqual(m_rb.call_count, 5)
+        self.assertEqual(m_set.call_count, webhook._STATUS_RETRY_ATTEMPTS, "one set_value per attempt")
+        self.assertEqual(
+            m_rb.call_count,
+            webhook._STATUS_RETRY_ATTEMPTS + 1,
+            "one up-front rollback + one per attempt",
+        )
         m_commit.assert_not_called()
         self.assertEqual(m_log.call_count, 1, "logs once, on exhaustion")
 
@@ -67,12 +71,14 @@ class TestApplyWhatsappMessageStatus(FrappeTestCase):
             patch.object(webhook.frappe.db, "get_value", return_value=None),
             patch.object(webhook.frappe.db, "set_value") as m_set,
             patch.object(webhook.frappe.db, "commit") as m_commit,
+            patch.object(webhook.frappe.db, "rollback") as m_rb,
             patch.object(webhook.frappe, "log_error") as m_log,
         ):
             webhook.apply_whatsapp_message_status("wamid.unknown", "read")
         m_set.assert_not_called()
         m_commit.assert_not_called()
         m_log.assert_not_called()
+        self.assertEqual(m_rb.call_count, 2, "up-front rollback + no-op-path rollback")
 
     def test_conversation_id_included_when_present(self):
         _m_get, m_set, _m_commit, _m_rb, _m_log = self._run(conversation="CONV-9")

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/test_whatsapp_message.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/test_whatsapp_message.py
@@ -2,11 +2,86 @@
 # Copyright (c) 2022, Shridhar Patil and Contributors
 # See license.txt
 
-# import frappe
-from frappe.tests import UnitTestCase
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from frappe_whatsapp.utils import webhook
 
 
-class TestWhatsAppMessage(UnitTestCase):
+class TestWhatsAppMessage(FrappeTestCase):
     """Test whatsapp messages."""
 
     pass
+
+
+class TestApplyWhatsappMessageStatus(FrappeTestCase):
+    """apply_whatsapp_message_status retries through transient 1020/1213 and is non-fatal.
+
+    Fully mocked — the WhatsApp Message row + frappe.db calls are patched, so no DB / no site state.
+    """
+
+    def _run(self, set_value_side_effect=None, name="WA-MSG-1", conversation=None):
+        with (
+            patch.object(webhook.frappe.db, "get_value", return_value=name) as m_get,
+            patch.object(webhook.frappe.db, "set_value", side_effect=set_value_side_effect) as m_set,
+            patch.object(webhook.frappe.db, "commit") as m_commit,
+            patch.object(webhook.frappe.db, "rollback") as m_rb,
+            patch.object(webhook.time, "sleep"),
+            patch.object(webhook.frappe, "log_error") as m_log,
+        ):
+            webhook.apply_whatsapp_message_status("wamid.X", "delivered", conversation=conversation)
+        return m_get, m_set, m_commit, m_rb, m_log
+
+    def test_retries_through_conflict_then_succeeds(self):
+        """Two 1020s then success → set_value retried, committed once, nothing logged."""
+        calls = {"n": 0}
+
+        def se(*a, **k):
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise frappe.QueryDeadlockError("1020 record has changed")
+
+        _m_get, m_set, m_commit, m_rb, m_log = self._run(set_value_side_effect=se)
+        self.assertEqual(m_set.call_count, 3, "set_value retried until it succeeds")
+        self.assertEqual(m_commit.call_count, 1, "commit once, after the successful UPDATE")
+        self.assertEqual(m_rb.call_count, 2, "rollback before each of the 2 retries (fresh snapshot)")
+        m_log.assert_not_called()
+
+    def test_exhaustion_logs_once_and_does_not_raise(self):
+        """Persistent conflict → exhausts attempts, logs once, never raises (non-fatal job)."""
+
+        def se(*a, **k):
+            raise frappe.QueryTimeoutError("1205 lock wait timeout")
+
+        _m_get, m_set, m_commit, m_rb, m_log = self._run(set_value_side_effect=se)  # must not raise
+        self.assertEqual(m_set.call_count, 5, "exactly _STATUS_RETRY_ATTEMPTS attempts")
+        self.assertEqual(m_rb.call_count, 5)
+        m_commit.assert_not_called()
+        self.assertEqual(m_log.call_count, 1, "logs once, on exhaustion")
+
+    def test_missing_message_is_noop(self):
+        """A status for a message we do not store no-ops — no UPDATE, no error."""
+        with (
+            patch.object(webhook.frappe.db, "get_value", return_value=None),
+            patch.object(webhook.frappe.db, "set_value") as m_set,
+            patch.object(webhook.frappe.db, "commit") as m_commit,
+            patch.object(webhook.frappe, "log_error") as m_log,
+        ):
+            webhook.apply_whatsapp_message_status("wamid.unknown", "read")
+        m_set.assert_not_called()
+        m_commit.assert_not_called()
+        m_log.assert_not_called()
+
+    def test_conversation_id_included_when_present(self):
+        _m_get, m_set, _m_commit, _m_rb, _m_log = self._run(conversation="CONV-9")
+        values = m_set.call_args[0][2]  # set_value(doctype, name, values)
+        self.assertEqual(values.get("status"), "delivered")
+        self.assertEqual(values.get("conversation_id"), "CONV-9")
+
+    def test_conversation_id_omitted_when_absent(self):
+        _m_get, m_set, _m_commit, _m_rb, _m_log = self._run(conversation=None)
+        values = m_set.call_args[0][2]
+        self.assertEqual(values.get("status"), "delivered")
+        self.assertNotIn("conversation_id", values)

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.js
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.js
@@ -2,6 +2,13 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('WhatsApp Message', {
+	onload: function(frm) {
+		frappe.db.get_single_value('WhatsApp Settings', 'allow_auto_read_receipt').then(value => {
+			if (value && frm.doc.type === "Incoming" && frm.doc.status !== "marked as read" && frm.doc.message_id) {
+				send_read_receipt(frm);
+			}
+		});
+	},
 	refresh: function(frm) {
 		if (frm.doc.type == 'Incoming'){
 			frm.add_custom_button(__("Reply"), function(){
@@ -28,11 +35,16 @@ frappe.ui.form.on('WhatsApp Message', {
 
 // custom button
 function add_mark_as_read(frm){
-	if(frm.doc.type === "Incoming" && frm.doc.status !== "marked as read" && frm.doc.message_id){
+	if(frm.doc.type === "Outgoing" || frm.doc.status == "marked as read" || !frm.doc.message_id)
+		return
+	
+	frappe.db.get_single_value('WhatsApp Settings', 'allow_auto_read_receipt').then(value => {
+		if (value) return; // return if auto read receipt is enabled
+
 		frm.add_custom_button(__('Mark as read'), function(){
 			send_read_receipt(frm);
 		});
-	}
+	});
 }
 
 function send_read_receipt(frm) {

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.js
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.js
@@ -9,5 +9,29 @@ frappe.ui.form.on('WhatsApp Message', {
 
 			});
 		}
+
+		// add custom button to send read receipt
+		add_mark_as_read(frm);
 	}
 });
+
+// custom button
+function add_mark_as_read(frm){
+	if(frm.doc.type === "Incoming" && frm.doc.status !== "marked as read" && frm.doc.message_id){
+		frm.add_custom_button(__('Mark as read'), function(){
+			send_read_receipt(frm);
+		});
+	}
+}
+
+function send_read_receipt(frm) {
+	frappe.call({
+		doc: frm.doc,
+		method: "send_read_receipt",
+		callback: function(r) {
+			if (r && r.message) {
+				frappe.msgprint(__('Marked as read'));
+			}
+		}
+	});
+}

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.js
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.js
@@ -9,5 +9,16 @@ frappe.ui.form.on('WhatsApp Message', {
 
 			});
 		}
+	},
+
+	use_template: function(frm){
+		// set to default
+		frm.set_value("message_type", "Manual");
+
+		if (frm.doc.use_template) {
+			frm.set_value("message_type", "Template");
+		}
+
+		frm.refresh_field("message_type");
 	}
 });

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.json
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.json
@@ -23,6 +23,7 @@
   "conversation_id",
   "content_type",
   "attach",
+  "template_button_parameters",
   "section_break_iyjf",
   "is_reply",
   "reply_to_message_id",
@@ -185,15 +186,21 @@
    "label": "bulk_message_reference"
   },
   {
-    "fieldname": "profile_name",
-    "fieldtype": "Data",
-    "label": "Profile Name",
-    "read_only": 1
-   }
+   "fieldname": "profile_name",
+   "fieldtype": "Data",
+   "label": "Profile Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "template_button_parameters",
+   "fieldtype": "Small Text",
+   "label": "Template Button Parameters",
+   "read_only": 1
+  }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-03-13 12:03:12.896651",
+ "modified": "2025-08-25 10:56:28.813705",
  "modified_by": "Administrator",
  "module": "Frappe Whatsapp",
  "name": "WhatsApp Message",
@@ -213,6 +220,7 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.json
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.json
@@ -24,6 +24,7 @@
   "content_type",
   "attach",
   "template_button_parameters",
+  "body_param",
   "section_break_iyjf",
   "is_reply",
   "reply_to_message_id",
@@ -140,7 +141,7 @@
   },
   {
    "allow_in_quick_entry": 1,
-   "depends_on": "eval:(doc.content_type =='audio' || doc.content_type =='video' || doc.content_type =='document' || doc.content_type =='image')",
+   "depends_on": "eval:(doc.content_type =='audio' || doc.content_type =='video' || doc.content_type =='document' || doc.content_type =='image' || doc.message_type=='Template')",
    "fieldname": "attach",
    "fieldtype": "Attach",
    "label": "Attach"
@@ -197,6 +198,11 @@
    "fieldtype": "Small Text",
    "label": "Template Button Parameters",
    "read_only": 1
+  },
+  {
+   "fieldname": "body_param",
+   "fieldtype": "JSON",
+   "label": "Body Param"
   }
  ],
  "index_web_pages_for_search": 1,

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.json
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.json
@@ -84,6 +84,7 @@
    "fieldname": "template",
    "fieldtype": "Link",
    "label": "Template",
+   "mandatory_depends_on": "eval:doc.use_template == 1",
    "options": "WhatsApp Templates"
   },
   {
@@ -200,7 +201,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-08-27 14:33:19.339964",
+ "modified": "2025-08-29 10:56:15.570894",
  "modified_by": "Administrator",
  "module": "Frappe Whatsapp",
  "name": "WhatsApp Message",

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.json
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.json
@@ -133,7 +133,7 @@
    "fieldname": "content_type",
    "fieldtype": "Select",
    "label": "Content Type",
-   "options": "text\ndocument\nimage\nvideo\naudio\nflow\nreaction\nlocation\ncontact\nbutton",
+   "options": "text\ndocument\nimage\nvideo\naudio\nflow\nreaction\nlocation\ncontact\nbutton\nunsupported",
    "reqd": 1
   },
   {
@@ -193,7 +193,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-03-13 12:03:12.896651",
+ "modified": "2025-08-27 14:33:19.339964",
  "modified_by": "Administrator",
  "module": "Frappe Whatsapp",
  "name": "WhatsApp Message",
@@ -213,6 +213,7 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.json
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.json
@@ -10,7 +10,9 @@
   "type",
   "status",
   "to",
+  "to_normalized",
   "from",
+  "from_normalized",
   "profile_name",
   "use_template",
   "template",
@@ -203,11 +205,25 @@
    "fieldname": "body_param",
    "fieldtype": "JSON",
    "label": "Body Param"
+  },
+  {
+   "fieldname": "to_normalized",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "To Normalized",
+   "search_index": 1
+  },
+  {
+   "fieldname": "from_normalized",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "From Normalized",
+   "search_index": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-08-29 10:56:15.570894",
+ "modified": "2026-06-23 20:15:47.187524",
  "modified_by": "Administrator",
  "module": "Frappe Whatsapp",
  "name": "WhatsApp Message",

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.json
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.json
@@ -125,7 +125,8 @@
    "fieldname": "message_id",
    "fieldtype": "Data",
    "label": "Message ID",
-   "read_only": 1
+   "read_only": 1,
+   "search_index": 1
   },
   {
    "fieldname": "conversation_id",

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.py
@@ -69,7 +69,12 @@ class WhatsAppMessage(Document):
             parameters = []
             template_parameters = []
 
-            if self.flags.custom_ref_doc:
+            if self.body_param is not None:
+                params = list(json.loads(self.body_param).values())
+                for param in params:
+                    parameters.append({"type": "text", "text": param})
+                    template_parameters.append(param)
+            elif self.flags.custom_ref_doc:
                 custom_values = self.flags.custom_ref_doc
                 for field_name in field_names:
                     value = custom_values.get(field_name.strip())
@@ -80,13 +85,10 @@ class WhatsAppMessage(Document):
                 ref_doc = frappe.get_doc(self.reference_doctype, self.reference_name)
                 for field_name in field_names:
                     value = ref_doc.get_formatted(field_name.strip())
-
                     parameters.append({"type": "text", "text": value})
                     template_parameters.append(value)
 
-
             self.template_parameters = json.dumps(template_parameters)
-
             data["template"]["components"].append(
                 {
                     "type": "body",
@@ -94,21 +96,39 @@ class WhatsAppMessage(Document):
                 }
             )
 
-        if template.header_type and template.sample:
-            if template.header_type == 'IMAGE':
-                if template.sample.startswith("http"):
-                    url = f'{template.sample}'
-                else:
-                    url = f'{frappe.utils.get_url()}{template.sample}'
-                data['template']['components'].append({
-                    "type": "header",
-                    "parameters": [{
-                        "type": "image",
-                        "image": {
-                            "link": url
-                        }
-                    }]
-            })
+        if template.header_type:
+            if self.attach:
+                if template.header_type == 'IMAGE':
+
+                    if self.attach.startswith("http"):
+                        url = f'{self.attach}'
+                    else:
+                        url = f'{frappe.utils.get_url()}{self.attach}'
+                    data['template']['components'].append({
+                        "type": "header",
+                        "parameters": [{
+                            "type": "image",
+                            "image": {
+                                "link": url
+                            }
+                        }]
+                    })
+
+            elif template.sample:
+                if template.header_type == 'IMAGE':
+                    if template.sample.startswith("http"):
+                        url = f'{template.sample}'
+                    else:
+                        url = f'{frappe.utils.get_url()}{template.sample}'
+                    data['template']['components'].append({
+                        "type": "header",
+                        "parameters": [{
+                            "type": "image",
+                            "image": {
+                                "link": url
+                            }
+                        }]
+                    })
 
         if template.need_dynamic_button_url_parameter:
             button_field_names = template.field_name_for_button_parameter.split(",")

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.py
@@ -5,10 +5,19 @@ import frappe
 from frappe.model.document import Document
 from frappe.integrations.utils import make_post_request
 import urllib.parse
-
+from frappe.query_builder import Interval
+from frappe.query_builder.functions import Now
 
 class WhatsAppMessage(Document):
     """Send whats app messages."""
+
+    @staticmethod
+    def clear_old_logs(days=90):
+        whatsapp_message = frappe.qb.DocType("WhatsApp Message")
+        frappe.db.delete(
+			whatsapp_message,
+			filters=(whatsapp_message.modified < (Now() - Interval(days=days))),
+		)
 
     def before_insert(self):
         """Send message."""

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/whatsapp_notification.js
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/whatsapp_notification.js
@@ -10,8 +10,12 @@ frappe.notification = {
 		frappe.model.with_doctype(frm.doc.reference_doctype, function () {
 			let get_select_options = function (df, parent_field) {
 				// Append parent_field name along with fieldname for child table fields
-				let select_value = parent_field ? df.fieldname + "," + parent_field : df.fieldname;
-				let path = parent_field ? parent_field + " > " + df.fieldname : df.fieldname;
+				let select_value = parent_field
+					? df.fieldname + "," + parent_field
+					: df.fieldname;
+				let path = parent_field
+					? parent_field + " > " + df.fieldname
+					: df.fieldname;
 
 				return {
 					value: select_value,
@@ -28,7 +32,10 @@ frappe.notification = {
 				// append creation and modified date to Date Change field
 				return date_options.concat([
 					{ value: "creation", label: `creation (${__("Created On")})` },
-					{ value: "modified", label: `modified (${__("Last Modified Date")})` },
+					{
+						value: "modified",
+						label: `modified (${__("Last Modified Date")})`,
+					},
 				]);
 			};
 
@@ -44,123 +51,142 @@ frappe.notification = {
 
 			// set value changed options
 			frm.set_df_property("value_changed", "options", [""].concat(options));
-			frm.set_df_property("set_property_after_alert", "options", [""].concat(options));
+			frm.set_df_property(
+				"set_property_after_alert",
+				"options",
+				[""].concat(options)
+			);
 		});
 	},
 	setup_alerts_button: function (frm) {
 		// body...
-		frm.add_custom_button(__('Get Alerts for Today'), function () {
+		frm.add_custom_button(__("Get Alerts for Today"), function () {
 			frappe.call({
-				method: 'frappe_whatsapp.frappe_whatsapp.doctype.whatsapp_notification.whatsapp_notification.call_trigger_notifications',
+				method:
+					"frappe_whatsapp.frappe_whatsapp.doctype.whatsapp_notification.whatsapp_notification.call_trigger_notifications",
 				args: {
-					method: 'daily'
+					method: "daily",
 				},
 				callback: function (response) {
 					if (response.message && response.message.length > 0) {
 					} else {
-						frappe.msgprint(__('No alerts for today'));
+						frappe.msgprint(__("No alerts for today"));
 					}
 				},
 				error: function (error) {
-					frappe.msgprint(__('Failed to trigger notifications'));
-				}
+					frappe.msgprint(__("Failed to trigger notifications"));
+				},
 			});
 		});
-	}
+	},
 };
 
-
-frappe.ui.form.on('WhatsApp Notification', {
+frappe.ui.form.on("WhatsApp Notification", {
 	refresh: function (frm) {
-		frm.trigger("load_template")
+		frm.trigger("load_template");
 		frappe.notification.setup_fieldname_select(frm);
 		frappe.notification.setup_alerts_button(frm);
 	},
 	template: function (frm) {
 		frm.trigger("load_template");
 	},
-
 	load_template: function (frm) {
 		frappe.db.get_value(
 			"WhatsApp Templates",
 			frm.doc.template,
-			["template", "header_type", "need_button_in_template", "template_buttons_json", "need_dynamic_button_url_parameter", "field_name_for_button_parameter"],
+			[
+				"template",
+				"header_type",
+				"need_button_in_template",
+				"template_buttons_json",
+				"need_dynamic_button_url_parameter",
+				"field_name_for_button_parameter",
+			],
 			(r) => {
 				if (r && r.template) {
-					frm.set_value('header_type', r.header_type)
-					frm.refresh_field("header_type")
-					if (['DOCUMENT', "IMAGE"].includes(r.header_type)) {
+					frm.set_value("header_type", r.header_type);
+					frm.refresh_field("header_type");
+					if (["DOCUMENT", "IMAGE"].includes(r.header_type)) {
 						frm.toggle_display("custom_attachment", true);
 						frm.toggle_display("attach_document_print", true);
 						if (!frm.doc.custom_attachment) {
-							frm.set_value("attach_document_print", 1)
+							frm.set_value("attach_document_print", 1);
 						}
 					} else {
 						frm.toggle_display("custom_attachment", false);
 						frm.toggle_display("attach_document_print", false);
-						frm.set_value("attach_document_print", 0)
-						frm.set_value("custom_attachment", 0)
+						frm.set_value("attach_document_print", 0);
+						frm.set_value("custom_attachment", 0);
 					}
 
-					frm.refresh_field("custom_attachment")
+					frm.refresh_field("custom_attachment");
 
 					frm.set_value("code", r.template);
-					frm.refresh_field("code")
+					frm.refresh_field("code");
 				}
 
 				if (r && r.need_button_in_template) {
 					let button_urls = "";
-					r.template_buttons_json = JSON.parse(r.template_buttons_json)
+					r.template_buttons_json = JSON.parse(r.template_buttons_json);
 
 					// Build button URLs string from template buttons
-					r.template_buttons_json.forEach(btn => {
+					r.template_buttons_json.forEach((btn) => {
 						button_urls += btn.url + "\n";
 						button_urls = button_urls.trim();
 					});
 
 					// Only update if value changed to keep form clean
 					if (frm.doc.button_urls !== button_urls) {
-						frm.set_value('button_urls', button_urls);
+						frm.set_value("button_urls", button_urls);
 					}
 
 					if (r.need_dynamic_button_url_parameter) {
 						// Extract potential dynamic fields from template
-						const fields = r.field_name_for_button_parameter ? r.field_name_for_button_parameter.split("\n") : [];
-						let existing_fields = (frm.doc.button_url_fields || []).map(row => row.field_name);
+						const fields = r.field_name_for_button_parameter
+							? r.field_name_for_button_parameter.split("\n")
+							: [];
+						let existing_fields = (frm.doc.button_url_fields || []).map(
+							(row) => row.field_name
+						);
 
 						// Replace only if the field set is different (avoid dirty form)
 						if (JSON.stringify(existing_fields) !== JSON.stringify(fields)) {
 							frm.clear_table("button_url_fields");
 
 							// Populate child table with dynamic fields
-							fields.forEach(field => {
+							fields.forEach((field) => {
 								frm.add_child("button_url_fields", { field_name: field });
 							});
 						}
 					}
-
-					frm.refresh_field("button_urls");
-					frm.refresh_field("button_url_fields");
+				} else {
+					frm.set_value("button_urls", "");
+					frm.clear_table("button_url_fields");
 				}
+				frm.refresh_field("button_urls");
+				frm.refresh_field("button_url_fields");
 			}
-		)
+		);
 	},
 	custom_attachment: function (frm) {
-		if (frm.doc.custom_attachment == 1 && ['DOCUMENT', "IMAGE"].includes(frm.doc.header_type)) {
-			frm.set_df_property('file_name', 'reqd', frm.doc.custom_attachment)
+		if (
+			frm.doc.custom_attachment == 1 &&
+			["DOCUMENT", "IMAGE"].includes(frm.doc.header_type)
+		) {
+			frm.set_df_property("file_name", "reqd", frm.doc.custom_attachment);
 		} else {
-			frm.set_df_property('file_name', 'reqd', 0)
+			frm.set_df_property("file_name", "reqd", 0);
 		}
 
 		// frm.toggle_display("attach_document_print", !frm.doc.custom_attachment);
 		if (frm.doc.header_type) {
-			frm.set_value("attach_document_print", !frm.doc.custom_attachment)
+			frm.set_value("attach_document_print", !frm.doc.custom_attachment);
 		}
 	},
 	attach_document_print: function (frm) {
 		// frm.toggle_display("custom_attachment", !frm.doc.attach_document_print);
-		if (['DOCUMENT', "IMAGE"].includes(frm.doc.header_type)) {
-			frm.set_value("custom_attachment", !frm.doc.attach_document_print)
+		if (["DOCUMENT", "IMAGE"].includes(frm.doc.header_type)) {
+			frm.set_value("custom_attachment", !frm.doc.attach_document_print);
 		}
 	},
 	reference_doctype: function (frm) {

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/whatsapp_notification.json
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/whatsapp_notification.json
@@ -26,8 +26,10 @@
   "file_name",
   "section_break_11",
   "condition",
+  "button_urls",
   "column_break_12",
   "fields",
+  "button_url_fields",
   "property_section",
   "set_property_after_alert",
   "property_value",
@@ -208,11 +210,24 @@
    "label": "Notification Name",
    "reqd": 1,
    "unique": 1
+  },
+  {
+   "fieldname": "button_urls",
+   "fieldtype": "Small Text",
+   "label": "Button URLs",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval: doc.button_urls",
+   "fieldname": "button_url_fields",
+   "fieldtype": "Table",
+   "label": "Button URL Fields",
+   "options": "WhatsApp Message Fields"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-03-03 11:30:47.397819",
+ "modified": "2025-08-25 14:03:57.447197",
  "modified_by": "Administrator",
  "module": "Frappe Whatsapp",
  "name": "WhatsApp Notification",
@@ -232,6 +247,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/whatsapp_notification.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/whatsapp_notification.py
@@ -260,7 +260,7 @@ class WhatsAppNotification(Document):
                 parameters = [param["text"] for param in data["template"]["components"][0]["parameters"]]
                 parameters = frappe.json.dumps(parameters, default=str)
 
-            if data["template"]["components"] and len(data["template"]["components"]) > 1:
+            if data["template"]["components"] and any(component["type"] == "button" for component in data["template"]["components"]):
                 button_parameters = [param["text"] for param in data["template"]["components"][1]["parameters"]]
                 button_parameters = frappe.json.dumps(button_parameters, default=str)
 

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_settings/whatsapp_settings.json
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_settings/whatsapp_settings.json
@@ -44,9 +44,11 @@
    "label": "Business ID"
   },
   {
+    "default": "secret",
    "fieldname": "webhook_verify_token",
-   "fieldtype": "Data",
-   "label": "Webhook Verify Token"
+   "fieldtype": "Password",
+   "label": "Webhook Verify Token",
+   "read_only": 1
   },
   {
    "default": "0",
@@ -70,7 +72,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-10-02 18:09:26.499196",
+ "modified": "2025-10-11 12:51:10.291950",
  "modified_by": "Administrator",
  "module": "Frappe Whatsapp",
  "name": "WhatsApp Settings",

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_settings/whatsapp_settings.json
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_settings/whatsapp_settings.json
@@ -7,6 +7,7 @@
  "engine": "InnoDB",
  "field_order": [
   "enabled",
+  "allow_auto_read_receipt",
   "token",
   "url",
   "version",
@@ -57,12 +58,19 @@
    "fieldname": "app_id",
    "fieldtype": "Data",
    "label": "App ID"
+  },
+  {
+   "default": "1",
+   "fieldname": "allow_auto_read_receipt",
+   "fieldtype": "Check",
+   "label": "Allow Auto Read Receipt"
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-05-03 12:42:25.851544",
+ "modified": "2025-10-02 18:09:26.499196",
  "modified_by": "Administrator",
  "module": "Frappe Whatsapp",
  "name": "WhatsApp Settings",
@@ -79,6 +87,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_templates/whatsapp_templates.json
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_templates/whatsapp_templates.json
@@ -21,6 +21,10 @@
   "category",
   "language",
   "language_code",
+  "need_button_in_template",
+  "template_buttons_json",
+  "need_dynamic_button_url_parameter",
+  "field_name_for_button_parameter",
   "section_break_lupb",
   "header_type",
   "header",
@@ -146,11 +150,39 @@
    "fieldname": "field_names",
    "fieldtype": "Small Text",
    "label": "Field names"
+  },
+  {
+   "default": "0",
+   "fieldname": "need_dynamic_button_url_parameter",
+   "fieldtype": "Check",
+   "label": "Need Dynamic Button URL Parameter"
+  },
+  {
+   "depends_on": "eval: doc.need_dynamic_button_url_parameter == 1",
+   "fieldname": "field_name_for_button_parameter",
+   "fieldtype": "Small Text",
+   "label": "Field Name For Button Parameter",
+   "mandatory_depends_on": "eval: doc.need_dynamic_button_url_parameter == 1"
+  },
+  {
+   "default": "[\n    {\n        \"type\": \"URL\",\n        \"text\": \"Visit website\",\n        \"url\": \"https://xyz.ptstdm.in/app/lead/{{1}}\",\n        \"example\": [\n            \"https://xyz.ptstdm.in/app/lead/Lead-001\"\n        ]\n    }\n]",
+   "depends_on": "eval: doc.need_button_in_template == 1",
+   "fieldname": "template_buttons_json",
+   "fieldtype": "JSON",
+   "label": "Template Buttons JSON",
+   "mandatory_depends_on": "eval: doc.need_button_in_template == 1"
+  },
+  {
+   "default": "0",
+   "fieldname": "need_button_in_template",
+   "fieldtype": "Check",
+   "label": "Need Button in Template"
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-08-19 12:22:17.367586",
+ "modified": "2025-08-25 10:23:44.526215",
  "modified_by": "Administrator",
  "module": "Frappe Whatsapp",
  "name": "WhatsApp Templates",
@@ -170,6 +202,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_templates/whatsapp_templates.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_templates/whatsapp_templates.py
@@ -26,7 +26,15 @@ class WhatsAppTemplates(Document):
         if not self.need_button_in_template:
             self.template_buttons_json = None
 
-        if not self.is_new():
+        if not self.is_new() and (
+            self.has_value_changed("template") or 
+            self.has_value_changed("sample_values") or 
+            self.has_value_changed("template_buttons_json") or 
+            self.has_value_changed("header_type") or 
+            self.has_value_changed("header") or 
+            self.has_value_changed("footer") or
+            self.has_value_changed("sample")
+        ):
             self.update_template()
 
 

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_templates/whatsapp_templates.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_templates/whatsapp_templates.py
@@ -26,8 +26,8 @@ class WhatsAppTemplates(Document):
         if not self.need_button_in_template:
             self.template_buttons_json = None
 
-        # if not self.is_new():
-        #     self.update_template()
+        if not self.is_new():
+            self.update_template()
 
 
     def get_session_id(self):

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_templates/whatsapp_templates.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_templates/whatsapp_templates.py
@@ -26,8 +26,8 @@ class WhatsAppTemplates(Document):
         if not self.need_button_in_template:
             self.template_buttons_json = None
 
-        if not self.is_new():
-            self.update_template()
+        # if not self.is_new():
+        #     self.update_template()
 
 
     def get_session_id(self):

--- a/frappe_whatsapp/hooks.py
+++ b/frappe_whatsapp/hooks.py
@@ -218,3 +218,7 @@ doc_events = {
         "on_update_after_submit": "frappe_whatsapp.utils.run_server_script_for_doc_event"
     }
 }
+
+default_log_clearing_doctypes = {
+    "WhatsApp Message": 90,
+}

--- a/frappe_whatsapp/patches.txt
+++ b/frappe_whatsapp/patches.txt
@@ -1,0 +1,6 @@
+[pre_model_sync]
+# Patches added in this section will be executed before doctypes are migrated
+
+[post_model_sync]
+# Patches added in this section will be executed after doctypes are migrated
+frappe_whatsapp.patches.set_default_in_whatsapp_settings #1

--- a/frappe_whatsapp/patches/set_default_in_whatsapp_settings.py
+++ b/frappe_whatsapp/patches/set_default_in_whatsapp_settings.py
@@ -3,4 +3,5 @@ import frappe
 def execute():
     settings = frappe.get_single("WhatsApp Settings")
     settings.allow_auto_read_receipt = 1
+    settings.webhook_verify_token = 'secret'
     settings.save()

--- a/frappe_whatsapp/patches/set_default_in_whatsapp_settings.py
+++ b/frappe_whatsapp/patches/set_default_in_whatsapp_settings.py
@@ -1,0 +1,6 @@
+import frappe
+
+def execute():
+    settings = frappe.get_single("WhatsApp Settings")
+    settings.allow_auto_read_receipt = 1
+    settings.save()

--- a/frappe_whatsapp/utils/webhook.py
+++ b/frappe_whatsapp/utils/webhook.py
@@ -2,7 +2,7 @@
 import frappe
 import json
 import requests
-import time
+from frappe.utils.password import get_decrypted_password
 from werkzeug.wrappers import Response
 import frappe.utils
 
@@ -18,9 +18,7 @@ def webhook():
 def get():
 	"""Get."""
 	hub_challenge = frappe.form_dict.get("hub.challenge")
-	webhook_verify_token = frappe.db.get_single_value(
-		"WhatsApp Settings", "webhook_verify_token"
-	)
+	webhook_verify_token = get_decrypted_password("WhatsApp Settings", "WhatsApp Settings", "webhook_verify_token")
 
 	if frappe.form_dict.get("hub.verify_token") != webhook_verify_token:
 		frappe.throw("Verify token does not match")

--- a/frappe_whatsapp/utils/webhook.py
+++ b/frappe_whatsapp/utils/webhook.py
@@ -155,6 +155,20 @@ def post():
 					"content_type": message_type,
 					"profile_name":sender_profile_name
 				}).insert(ignore_permissions=True)
+			elif message_type == "unsupported":
+				# Handle unsupported messages - save for reference and debugging
+				error_details = message.get('errors', [])
+				
+				frappe.get_doc({
+					"doctype": "WhatsApp Message",
+					"type": "Incoming", 
+					"from": message['from'],
+					"message": json.dumps(error_details),
+					"message_id": message['id'],
+					"reply_to_message_id": reply_to_message_id,
+					"content_type": message_type,
+					"profile_name": sender_profile_name
+				}).insert(ignore_permissions=True)
 			else:
 				frappe.get_doc({
 					"doctype": "WhatsApp Message",

--- a/frappe_whatsapp/utils/webhook.py
+++ b/frappe_whatsapp/utils/webhook.py
@@ -1,11 +1,21 @@
 """Webhook."""
-import frappe
 import json
+import random
+import time
+
+import frappe
 import requests
 from frappe.utils.password import get_decrypted_password
 from werkzeug.wrappers import Response
 import frappe.utils
 from frappe.utils.background_jobs import get_queues_timeout
+
+# A WhatsApp status UPDATE can hit a transient 1020/1213 under innodb_snapshot_isolation when concurrent
+# Meta callbacks (sent/delivered/read) + the chat "mark as read" race the same row. Retry through it — the
+# write is last-writer-wins + idempotent (re-delivered callbacks re-apply), and each retry's rollback gives
+# a fresh snapshot so it converges.
+_STATUS_RETRY_ATTEMPTS = 5
+_STATUS_RETRY_BASE_S = 0.05
 
 
 @frappe.whitelist(allow_guest=True)
@@ -237,67 +247,44 @@ def _whatsapp_status_queue():
 
 
 def apply_whatsapp_message_status(message_id, status, conversation=None):
-	"""Background job: apply a WhatsApp delivery-status update under READ COMMITTED.
+	"""Background job: apply a WhatsApp delivery-status update, retrying through transient lock conflicts.
 
-	MariaDB snapshot isolation (innodb_snapshot_isolation=ON) raises ER_CHECKREAD (1020) on a plain UPDATE
-	when another connection committed a change to this WhatsApp Message row after this transaction's read
-	view -- e.g. the outbound-send flow finalising the message, or a chat "mark as read". Running the write
-	under READ COMMITTED turns that conflict detection off (last-writer-wins, which is fine for a status
-	field), so the UPDATE just applies. A transaction's isolation is fixed when it starts and Frappe keeps a
-	transaction continuously open, so we capture the connection's current isolation, rollback to end that
-	transaction (without committing pending state), then SET SESSION READ COMMITTED for the next one. The
-	captured level is restored via a guarded helper that can never fail the job. Non-fatal + idempotent: a
-	status for a message we do not store no-ops, and re-delivered callbacks just re-apply.
+	Meta delivers sent/delivered/read (+ retries) as separate callbacks for the same message, and the chat
+	"mark as read" writes the same row, so concurrent status writes race. Under MariaDB snapshot isolation
+	(innodb_snapshot_isolation=ON) a plain UPDATE then raises ER_CHECKREAD (1020) when another connection
+	committed a change to this row since this transaction's read view. The status write is last-writer-wins +
+	idempotent (a missed callback re-applies on the next one), so we just retry: each attempt rolls back first
+	(`frappe.db.rollback()` re-begins the transaction, giving a fresh snapshot) and re-applies, with jittered
+	backoff. Non-fatal — a status for a message we don't store no-ops, and exhausted retries are logged only.
+
+	(We previously tried to run this under READ COMMITTED, but `frappe.db.rollback()` re-begins the transaction
+	with no isolation clause, so the UPDATE still ran at REPEATABLE READ — the retry is isolation-agnostic.)
 	"""
-	prior_isolation = None
-	try:
-		# Capture the connection's current isolation so we restore exactly it (not a hard-coded RR), then end
-		# the open transaction with a rollback (don't commit pending state) and switch to RC, under which
-		# snapshot isolation can't raise 1020 on the write (see docstring).
-		prior_isolation = frappe.db.sql("SELECT @@transaction_isolation")[0][0]
-		frappe.db.rollback()
-		frappe.db.sql("SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED")
-
-		name = frappe.db.get_value("WhatsApp Message", {"message_id": message_id})
-		if not name:
-			# Status for a message not stored here (e.g. sent from another system) — nothing to update.
+	for attempt in range(_STATUS_RETRY_ATTEMPTS):
+		try:
+			name = frappe.db.get_value("WhatsApp Message", {"message_id": message_id})
+			if not name:
+				# Status for a message not stored here (e.g. sent from another system) — nothing to update.
+				return
+			values = {"status": status}
+			if conversation:
+				values["conversation_id"] = conversation
+			frappe.db.set_value("WhatsApp Message", name, values)
+			frappe.db.commit()
 			return
-		values = {"status": status}
-		if conversation:
-			values["conversation_id"] = conversation
-		frappe.db.set_value("WhatsApp Message", name, values)
-		frappe.db.commit()
-	except Exception:
-		frappe.db.rollback()
-		frappe.log_error(
-			title="apply_whatsapp_message_status failed",
-			message=f"message_id={message_id}, status={status}\n{frappe.get_traceback()}",
-		)
-	finally:
-		_restore_session_isolation(prior_isolation)
-
-
-# @@transaction_isolation reports a hyphenated value (e.g. "REPEATABLE-READ"); SET SESSION needs the spaced
-# form. Whitelisted so the restore never interpolates an unexpected value into SQL.
-_ISOLATION_SQL = {
-	"REPEATABLE-READ": "REPEATABLE READ",
-	"READ-COMMITTED": "READ COMMITTED",
-	"READ-UNCOMMITTED": "READ UNCOMMITTED",
-	"SERIALIZABLE": "SERIALIZABLE",
-}
-
-
-def _restore_session_isolation(prior_isolation):
-	"""Restore the session isolation captured before the RC switch. Guarded so a failure here can never fail
-	the WhatsApp status job (nor mask the original error when raised from a `finally`)."""
-	level = _ISOLATION_SQL.get(prior_isolation)
-	if not level:
-		return
-	try:
-		frappe.db.rollback()
-		frappe.db.sql("SET SESSION TRANSACTION ISOLATION LEVEL " + level)
-	except Exception:
-		frappe.log_error(
-			title="apply_whatsapp_message_status: isolation restore failed",
-			message=f"prior={prior_isolation}\n{frappe.get_traceback()}",
-		)
+		except (frappe.QueryDeadlockError, frappe.QueryTimeoutError):
+			frappe.db.rollback()  # re-begins the txn → next attempt reads from a fresh snapshot
+			if attempt == _STATUS_RETRY_ATTEMPTS - 1:
+				frappe.log_error(
+					title="apply_whatsapp_message_status failed",
+					message=f"message_id={message_id}, status={status}\n{frappe.get_traceback()}",
+				)
+				return
+			time.sleep(_STATUS_RETRY_BASE_S * (2**attempt) + random.uniform(0, _STATUS_RETRY_BASE_S))
+		except Exception:
+			frappe.db.rollback()
+			frappe.log_error(
+				title="apply_whatsapp_message_status failed",
+				message=f"message_id={message_id}, status={status}\n{frappe.get_traceback()}",
+			)
+			return

--- a/frappe_whatsapp/utils/webhook.py
+++ b/frappe_whatsapp/utils/webhook.py
@@ -244,16 +244,19 @@ def apply_whatsapp_message_status(message_id, status, conversation=None):
 	view -- e.g. the outbound-send flow finalising the message, or a chat "mark as read". Running the write
 	under READ COMMITTED turns that conflict detection off (last-writer-wins, which is fine for a status
 	field), so the UPDATE just applies. A transaction's isolation is fixed when it starts and Frappe keeps a
-	transaction continuously open, so SET SESSION (which only affects the *next* transaction) is followed by
-	a commit to roll onto a fresh RC transaction; REPEATABLE READ is restored in `finally` because this job
-	may share a worker with others. Non-fatal + idempotent: a status for a message we do not store no-ops,
-	and re-delivered callbacks just re-apply.
+	transaction continuously open, so we capture the connection's current isolation, rollback to end that
+	transaction (without committing pending state), then SET SESSION READ COMMITTED for the next one. The
+	captured level is restored via a guarded helper that can never fail the job. Non-fatal + idempotent: a
+	status for a message we do not store no-ops, and re-delivered callbacks just re-apply.
 	"""
+	prior_isolation = None
 	try:
-		# Run the write under READ COMMITTED so snapshot isolation does not raise 1020 (see docstring). SET
-		# SESSION is allowed mid-transaction; the commit then rolls us onto a fresh transaction under RC.
+		# Capture the connection's current isolation so we restore exactly it (not a hard-coded RR), then end
+		# the open transaction with a rollback (don't commit pending state) and switch to RC, under which
+		# snapshot isolation can't raise 1020 on the write (see docstring).
+		prior_isolation = frappe.db.sql("SELECT @@transaction_isolation")[0][0]
+		frappe.db.rollback()
 		frappe.db.sql("SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED")
-		frappe.db.commit()
 
 		name = frappe.db.get_value("WhatsApp Message", {"message_id": message_id})
 		if not name:
@@ -271,7 +274,30 @@ def apply_whatsapp_message_status(message_id, status, conversation=None):
 			message=f"message_id={message_id}, status={status}\n{frappe.get_traceback()}",
 		)
 	finally:
-		# This job may run on the shared `short` worker until a dedicated `whatsapp` worker exists; restore
-		# the connection's default isolation so other jobs on it are not left on READ COMMITTED.
-		frappe.db.sql("SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ")
-		frappe.db.commit()
+		_restore_session_isolation(prior_isolation)
+
+
+# @@transaction_isolation reports a hyphenated value (e.g. "REPEATABLE-READ"); SET SESSION needs the spaced
+# form. Whitelisted so the restore never interpolates an unexpected value into SQL.
+_ISOLATION_SQL = {
+	"REPEATABLE-READ": "REPEATABLE READ",
+	"READ-COMMITTED": "READ COMMITTED",
+	"READ-UNCOMMITTED": "READ UNCOMMITTED",
+	"SERIALIZABLE": "SERIALIZABLE",
+}
+
+
+def _restore_session_isolation(prior_isolation):
+	"""Restore the session isolation captured before the RC switch. Guarded so a failure here can never fail
+	the WhatsApp status job (nor mask the original error when raised from a `finally`)."""
+	level = _ISOLATION_SQL.get(prior_isolation)
+	if not level:
+		return
+	try:
+		frappe.db.rollback()
+		frappe.db.sql("SET SESSION TRANSACTION ISOLATION LEVEL " + level)
+	except Exception:
+		frappe.log_error(
+			title="apply_whatsapp_message_status: isolation restore failed",
+			message=f"prior={prior_isolation}\n{frappe.get_traceback()}",
+		)

--- a/frappe_whatsapp/utils/webhook.py
+++ b/frappe_whatsapp/utils/webhook.py
@@ -253,18 +253,24 @@ def apply_whatsapp_message_status(message_id, status, conversation=None):
 	"mark as read" writes the same row, so concurrent status writes race. Under MariaDB snapshot isolation
 	(innodb_snapshot_isolation=ON) a plain UPDATE then raises ER_CHECKREAD (1020) when another connection
 	committed a change to this row since this transaction's read view. The status write is last-writer-wins +
-	idempotent (a missed callback re-applies on the next one), so we just retry: each attempt rolls back first
-	(`frappe.db.rollback()` re-begins the transaction, giving a fresh snapshot) and re-applies, with jittered
-	backoff. Non-fatal — a status for a message we don't store no-ops, and exhausted retries are logged only.
+	idempotent (a missed callback re-applies on the next one), so we just retry: we roll back once up front (a
+	reused worker connection can carry an open transaction with a stale read view) and again after each transient
+	conflict — every `frappe.db.rollback()` re-begins the transaction with a fresh snapshot — then re-apply, with
+	jittered backoff. Non-fatal — a status for a message we don't store no-ops, and exhausted retries are logged only.
 
 	(We previously tried to run this under READ COMMITTED, but `frappe.db.rollback()` re-begins the transaction
 	with no isolation clause, so the UPDATE still ran at REPEATABLE READ — the retry is isolation-agnostic.)
 	"""
+	# A reused RQ worker connection can carry an open transaction (stale read view) from a prior job; end it so
+	# attempt 1 also starts from a fresh snapshot, not just the post-conflict retries.
+	frappe.db.rollback()
 	for attempt in range(_STATUS_RETRY_ATTEMPTS):
 		try:
 			name = frappe.db.get_value("WhatsApp Message", {"message_id": message_id})
 			if not name:
 				# Status for a message not stored here (e.g. sent from another system) — nothing to update.
+				# Roll back so this job's read view isn't left open on the shared worker connection.
+				frappe.db.rollback()
 				return
 			values = {"status": status}
 			if conversation:

--- a/frappe_whatsapp/utils/webhook.py
+++ b/frappe_whatsapp/utils/webhook.py
@@ -237,15 +237,24 @@ def _whatsapp_status_queue():
 
 
 def apply_whatsapp_message_status(message_id, status, conversation=None):
-	"""Background job: apply a WhatsApp delivery-status update with a single direct UPDATE.
+	"""Background job: apply a WhatsApp delivery-status update under READ COMMITTED.
 
-	frappe.db.set_value issues a plain UPDATE (no optimistic-lock FOR UPDATE read), so concurrent status
-	updates for the same message serialize on a brief row lock instead of racing into a MariaDB 1020. It
-	keeps `modified`/`modified_by` fresh and clears the doc cache. Non-fatal and idempotent: a status for a
-	message we do not store no-ops, and re-delivered callbacks just re-apply (last-writer-wins; a single
-	FIFO 'whatsapp' worker preserves Meta's send order).
+	MariaDB snapshot isolation (innodb_snapshot_isolation=ON) raises ER_CHECKREAD (1020) on a plain UPDATE
+	when another connection committed a change to this WhatsApp Message row after this transaction's read
+	view -- e.g. the outbound-send flow finalising the message, or a chat "mark as read". Running the write
+	under READ COMMITTED turns that conflict detection off (last-writer-wins, which is fine for a status
+	field), so the UPDATE just applies. A transaction's isolation is fixed when it starts and Frappe keeps a
+	transaction continuously open, so SET SESSION (which only affects the *next* transaction) is followed by
+	a commit to roll onto a fresh RC transaction; REPEATABLE READ is restored in `finally` because this job
+	may share a worker with others. Non-fatal + idempotent: a status for a message we do not store no-ops,
+	and re-delivered callbacks just re-apply.
 	"""
 	try:
+		# Run the write under READ COMMITTED so snapshot isolation does not raise 1020 (see docstring). SET
+		# SESSION is allowed mid-transaction; the commit then rolls us onto a fresh transaction under RC.
+		frappe.db.sql("SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED")
+		frappe.db.commit()
+
 		name = frappe.db.get_value("WhatsApp Message", {"message_id": message_id})
 		if not name:
 			# Status for a message not stored here (e.g. sent from another system) — nothing to update.
@@ -261,3 +270,8 @@ def apply_whatsapp_message_status(message_id, status, conversation=None):
 			title="apply_whatsapp_message_status failed",
 			message=f"message_id={message_id}, status={status}\n{frappe.get_traceback()}",
 		)
+	finally:
+		# This job may run on the shared `short` worker until a dedicated `whatsapp` worker exists; restore
+		# the connection's default isolation so other jobs on it are not left on READ COMMITTED.
+		frappe.db.sql("SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ")
+		frappe.db.commit()

--- a/frappe_whatsapp/utils/webhook.py
+++ b/frappe_whatsapp/utils/webhook.py
@@ -5,6 +5,7 @@ import requests
 from frappe.utils.password import get_decrypted_password
 from werkzeug.wrappers import Response
 import frappe.utils
+from frappe.utils.background_jobs import get_queues_timeout
 
 
 @frappe.whitelist(allow_guest=True)
@@ -205,14 +206,58 @@ def update_template_status(data):
 	)
 
 def update_message_status(data):
-	"""Update message status."""
-	id = data['statuses'][0]['id']
-	status = data['statuses'][0]['status']
-	conversation = data['statuses'][0].get('conversation', {}).get('id')
-	name = frappe.db.get_value("WhatsApp Message", filters={"message_id": id})
+	"""Enqueue the WhatsApp delivery-status update off the request path.
 
-	doc = frappe.get_doc("WhatsApp Message", name)
-	doc.status = status
-	if conversation:
-		doc.conversation_id = conversation
-	doc.save(ignore_permissions=True)
+	Meta delivers sent/delivered/read (+ retries) as separate webhooks for the same message; writing it
+	inline via doc.save() raced the optimistic-lock SELECT ... FOR UPDATE under concurrent callbacks and
+	produced MariaDB 1020 ("Record has changed since last read"). We enqueue a direct-UPDATE job (after the
+	request commits) so the webhook returns 200 to Meta immediately and the write can't raise 1020.
+	"""
+	statuses = data.get("statuses")
+	if not statuses:
+		return
+	status_info = statuses[0]
+	frappe.enqueue(
+		"frappe_whatsapp.utils.webhook.apply_whatsapp_message_status",
+		queue=_whatsapp_status_queue(),
+		enqueue_after_commit=True,
+		message_id=status_info["id"],
+		status=status_info["status"],
+		conversation=status_info.get("conversation", {}).get("id"),
+	)
+
+
+def _whatsapp_status_queue():
+	"""Prefer a dedicated 'whatsapp' queue, falling back to 'short' until that queue is provisioned in
+	common_site_config['workers']. frappe.enqueue validates the queue name and raises for an unconfigured
+	one, so we choose a valid queue ourselves. get_queues_timeout() only reads the in-memory site conf, so
+	it is cheap to call per webhook.
+	"""
+	return "whatsapp" if "whatsapp" in get_queues_timeout() else "short"
+
+
+def apply_whatsapp_message_status(message_id, status, conversation=None):
+	"""Background job: apply a WhatsApp delivery-status update with a single direct UPDATE.
+
+	frappe.db.set_value issues a plain UPDATE (no optimistic-lock FOR UPDATE read), so concurrent status
+	updates for the same message serialize on a brief row lock instead of racing into a MariaDB 1020. It
+	keeps `modified`/`modified_by` fresh and clears the doc cache. Non-fatal and idempotent: a status for a
+	message we do not store no-ops, and re-delivered callbacks just re-apply (last-writer-wins; a single
+	FIFO 'whatsapp' worker preserves Meta's send order).
+	"""
+	try:
+		name = frappe.db.get_value("WhatsApp Message", {"message_id": message_id})
+		if not name:
+			# Status for a message not stored here (e.g. sent from another system) — nothing to update.
+			return
+		values = {"status": status}
+		if conversation:
+			values["conversation_id"] = conversation
+		frappe.db.set_value("WhatsApp Message", name, values)
+		frappe.db.commit()
+	except Exception:
+		frappe.db.rollback()
+		frappe.log_error(
+			title="apply_whatsapp_message_status failed",
+			message=f"message_id={message_id}, status={status}\n{frappe.get_traceback()}",
+		)


### PR DESCRIPTION
## Summary

- Added automated log cleanup support for WhatsApp Message.
- Registered WhatsApp Message in Log Settings with a default retention of 90 days.
- Implemented `clear_old_logs` to delete messages older than the configured retention period.

## Testing

- Verified WhatsApp Message appears in Log Settings.
- Verified the default retention is set to 90 days.
- Executed `WhatsAppMessage.clear_old_logs(90)` and confirmed that old WhatsApp Message records were deleted.