### PR TITLE
feat(webhook): echo originating flow_token on Flow (nfm_reply) replies

### DIFF
--- a/frappe_whatsapp/utils/test_webhook.py
+++ b/frappe_whatsapp/utils/test_webhook.py
@@ -480,3 +480,67 @@ class TestWebhookEndpoint(IntegrationTestCase):
         # Should have created a notification log
         logs = frappe.get_all("WhatsApp Notification Log", filters={"template": "Webhook"})
         self.assertTrue(len(logs) > 0)
+
+    def test_webhook_post_flow_reply_echoes_flow_token(self):
+        """Flow (nfm_reply) reply must echo the originating flow_token.
+
+        A client-only Flow reply carries no flow_token, so a sender cannot tell which
+        outbound Flow it answers. The webhook recovers the token from the outbound
+        message this reply is a context of and stores it on the incoming reply.
+        """
+        # Seed the outbound Flow message that carried the token.
+        origin = frappe.get_doc({
+            "doctype": "WhatsApp Message",
+            "type": "Outgoing",
+            "to": "919900112294",
+            "message": "Please complete the form",
+            "message_id": "wamid.webhook_ep_flow_origin",
+            "content_type": "flow",
+            "flow_token": "flow-token-abc123",
+            "whatsapp_account": "Test WA Webhook EP Account",
+        })
+        origin.flags.ignore_validate = True
+        origin.db_insert()
+        frappe.db.commit()  # nosemgrep: frappe-manual-commit -- test fixture must be visible to later queries
+
+        mock_request = self._make_mock_request("POST")
+        payload = {
+            "entry": [{
+                "changes": [{
+                    "value": {
+                        "metadata": {"phone_number_id": "webhook_ep_phone_id"},
+                        "contacts": [{"profile": {"name": "Flow User"}}],
+                        "messages": [{
+                            "from": "919900112294",
+                            "id": "wamid.webhook_ep_flow_reply_1",
+                            "type": "interactive",
+                            "interactive": {
+                                "type": "nfm_reply",
+                                "nfm_reply": {
+                                    "name": "flow",
+                                    "response_json": '{"field_a": "value_a", "field_b": "value_b"}',
+                                },
+                            },
+                            "context": {"id": "wamid.webhook_ep_flow_origin"},
+                        }]
+                    }
+                }]
+            }]
+        }
+        frappe.local.form_dict = frappe._dict(payload)
+
+        with patch("frappe_whatsapp.utils.webhook.frappe.request", mock_request):
+            from frappe_whatsapp.utils.webhook import webhook
+            webhook()
+
+        reply = frappe.get_doc(
+            "WhatsApp Message", {"message_id": "wamid.webhook_ep_flow_reply_1"}
+        )
+        self.assertEqual(reply.content_type, "flow")
+        self.assertEqual(reply.reply_to_message_id, "wamid.webhook_ep_flow_origin")
+        # the originating token is echoed onto the reply for correlation
+        self.assertEqual(reply.flow_token, "flow-token-abc123")
+        # the structured Flow response is preserved verbatim
+        self.assertEqual(
+            json.loads(reply.flow_response), {"field_a": "value_a", "field_b": "value_b"}
+        )

--- a/frappe_whatsapp/utils/webhook.py
+++ b/frappe_whatsapp/utils/webhook.py
@@ -152,6 +152,13 @@ def post():
 							summary_parts.append(f"{key}: {value}")
 					summary_message = ", ".join(summary_parts) if summary_parts else "Flow completed"
 
+					# Echo the originating flow_token: a client-only Flow reply does not carry it, so recover it
+					# from the outbound message this reply is a context of. Lets a sender correlate the reply back
+					# to what it sent (e.g. an e-signature Flow keyed by the signer's token).
+					origin_flow_token = frappe.db.get_value(
+						"WhatsApp Message", {"message_id": reply_to_message_id}, "flow_token"
+					) if reply_to_message_id else None
+
 					msg_doc = frappe.get_doc({
 						"doctype": "WhatsApp Message",
 						"type": "Incoming",
@@ -162,6 +169,7 @@ def post():
 						"is_reply": is_reply,
 						"content_type": "flow",
 						"flow_response": json.dumps(flow_response),
+						"flow_token": origin_flow_token,
 						"profile_name": sender_profile_name,
 						"whatsapp_account": whatsapp_account.name
 					}).insert(ignore_permissions=True)


### PR DESCRIPTION
## Problem

WhatsApp **client-only Flows** return their result as an `interactive.nfm_reply` webhook event. That payload does **not** include the `flow_token` that was set on the outbound Flow message — so a sender that dispatched a Flow has no reliable way to correlate the incoming reply back to the specific outbound message, and to the business context it represents.

Today `webhook.py` ingests the `nfm_reply` into an incoming `WhatsApp Message` (`content_type = "flow"`, `flow_response` JSON), but the correlation is dropped: there is only `reply_to_message_id`, so a caller has to keep its own side-table or re-join back to the outbound row to recover the token.

## Change

Recover the originating `flow_token` from the outbound message this reply is a context of (`reply_to_message_id`) and store it on the incoming reply's existing `flow_token` field.

- **Backwards compatible** — senders that don't set `flow_token` on outbound Flows are unaffected (`flow_token` stays null).
- **No new field / migration** — `WhatsApp Message.flow_token` already exists; this only populates it on the inbound side.
- **Self-contained** — a single `frappe.db.get_value` in the `nfm_reply` branch, guarded on `reply_to_message_id`.

## Why it matters

Any integration that dispatches Flows keyed by a business token — a form tied to a record, an appointment, a signing request — can now read `flow_token` straight off the incoming reply and route it, instead of re-deriving the link. It makes client-only Flows usable for round-trip request/response without extra bookkeeping.

## Tests

Adds `test_webhook_post_flow_reply_echoes_flow_token` to `frappe_whatsapp/utils/test_webhook.py` — the `nfm_reply` path had no coverage. It seeds an outbound Flow message carrying a `flow_token`, posts an `nfm_reply` whose `context.id` points at it, and asserts the incoming reply echoes the token and preserves the `flow_response` verbatim.
