### PR TITLE
fix: SRO-2026-06-00187 - add log cleanup support for WhatsApp Message

### DIFF
--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.py
@@ -5,7 +5,8 @@ import frappe
 from frappe import _, throw
 from frappe.model.document import Document
 from frappe.integrations.utils import make_post_request
-
+from frappe.query_builder import Interval
+from frappe.query_builder.functions import Now
 from frappe_whatsapp.utils import get_whatsapp_account, format_number
 
 class WhatsAppMessage(Document):
@@ -51,6 +52,13 @@ class WhatsAppMessage(Document):
                 self.whatsapp_account = default_whatsapp_account.name
 
     """Send whats app messages."""
+    @staticmethod
+    def clear_old_logs(days=90):
+        whatsapp_message = frappe.qb.DocType("WhatsApp Message")
+        frappe.db.delete(
+			whatsapp_message,
+			filters=(whatsapp_message.modified < (Now() - Interval(days=days))),
+		)
     def before_insert(self):
         """Send message."""
         self.set_whatsapp_account()

--- a/frappe_whatsapp/hooks.py
+++ b/frappe_whatsapp/hooks.py
@@ -218,3 +218,7 @@ doc_events = {
         "on_update_after_submit": "frappe_whatsapp.utils.run_server_script_for_doc_event"
     }
 }
+
+default_log_clearing_doctypes = {
+    "WhatsApp Message": 90,
+}


### PR DESCRIPTION
## Summary

- Added automated log cleanup support for WhatsApp Message.
- Registered WhatsApp Message in Log Settings with a default retention of 90 days.
- Implemented `clear_old_logs` to delete messages older than the configured retention period.

## Testing

- Verified WhatsApp Message appears in Log Settings.
- Verified the default retention is set to 90 days.
- Executed `WhatsAppMessage.clear_old_logs(90)` and confirmed that old WhatsApp Message records were deleted.