### PR TITLE
Lazy-import python-magic so loading the doctype doesn't require libmagic

### DIFF
--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_templates/whatsapp_templates.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_templates/whatsapp_templates.py
@@ -5,7 +5,6 @@
 import os
 import json
 import frappe
-import magic
 from frappe.model.document import Document
 from frappe.integrations.utils import make_post_request, make_request
 from frappe.desk.form.utils import get_pdf_link
@@ -41,6 +40,7 @@ class WhatsAppTemplates(Document):
         """Upload media."""
         self.get_settings()
         file_path = self.get_absolute_path(self.sample)
+        import magic  # lazy: needs system libmagic, only required when uploading media
         mime = magic.Magic(mime=True)
         file_type = mime.from_file(file_path)
 


### PR DESCRIPTION
### Problem

`whatsapp_templates.py` does `import magic` (python-magic) at module level. python-magic loads the native **libmagic** C library at import time, so merely *importing* the WhatsApp Templates controller requires libmagic to be installed.

`bench migrate` imports every installed app's doctype controllers (to run their `on_doctype_update` schema hooks). On a site where libmagic isn't installed, this makes **the entire migrate fail** with:

```
ImportError: Module import failed for WhatsApp Templates ...
Error: failed to find libmagic. Check your installation
```

— even when the WhatsApp media-upload feature is never used. `pip` pulls in `python-magic` but not the system `libmagic`, so this is easy to hit on fresh/dev environments.

### Fix

Move `import magic` into `get_session_id()`, the only place it's used (MIME detection when uploading template media). Behaviour is unchanged when that feature is used; libmagic is simply no longer required just to load or migrate the app.

The same one-line change applies to `master` if you'd like it there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)