### PR TITLE
fix: surface real error on template sync and autoname new templates

### DIFF
--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_templates/whatsapp_templates.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_templates/whatsapp_templates.py
@@ -407,24 +407,41 @@ def fetch():
             return "Successfully fetched templates from meta"
 
         except Exception as e:
-            # Check if frappe.flags.integration_request is set and has a .json() method
-            if hasattr(frappe.flags.integration_request, 'json'):
+            # frappe.flags.integration_request holds the *last* request made,
+            # which on this path is normally the successful GET above. Only use
+            # it when it actually carries an error payload, otherwise surface
+            # the real exception instead of throwing an empty message.
+            frappe.log_error(
+                title="WhatsApp: failed to fetch templates",
+                message=frappe.get_traceback(),
+            )
+
+            res = {}
+            if hasattr(frappe.flags.integration_request, "json"):
                 try:
-                    res = frappe.flags.integration_request.json().get("error", {})
-                    error_message = res.get("error_user_msg", res.get("message"))
-                    frappe.throw(
-                        msg=error_message,
-                        title=res.get("error_user_title", "Error"),
-                    )
-                except (json.JSONDecodeError, KeyError):
-                    # Handle cases where the response is not valid JSON or lacks the 'error' key
-                    frappe.throw(f"An unexpected error occurred while fetching templates: {e}")
-            else:
-                # Handle cases where frappe.flags.integration_request doesn't exist or isn't a proper response object
-                frappe.throw(f"An unexpected server error occurred: {e}")
+                    res = frappe.flags.integration_request.json().get("error") or {}
+                except (json.JSONDecodeError, AttributeError, KeyError):
+                    res = {}
+
+            error_message = res.get("error_user_msg") or res.get("message")
+            if error_message:
+                frappe.throw(
+                    msg=error_message,
+                    title=res.get("error_user_title", "Error"),
+                )
+
+            frappe.throw(
+                msg=f"An unexpected error occurred while fetching templates: {e}",
+                title="Error",
+            )
 
 def upsert_doc_without_hooks(doc, child_dt, child_field):
     """Insert or update a parent document and its children without hooks."""
+    # db_insert() does not run autoname, so a brand new doc would be inserted
+    # with name = None and fail on the NOT NULL constraint.
+    if not doc.name:
+        doc.set_new_name()
+
     if frappe.db.exists(doc.doctype, doc.name):
         doc.db_update()
         frappe.db.delete(child_dt, {"parent": doc.name, "parenttype": doc.doctype})


### PR DESCRIPTION
### Problem

Two bugs in `fetch()` that combine badly: a sync failure is reported as a dialog with no text, and the underlying traceback is discarded, so there is nothing to diagnose from.

**1. Empty error dialog**

```python
except Exception as e:
    if hasattr(frappe.flags.integration_request, 'json'):
        res = frappe.flags.integration_request.json().get("error", {})
        error_message = res.get("error_user_msg", res.get("message"))
        frappe.throw(msg=error_message, title=res.get("error_user_title", "Error"))
```

`frappe.flags.integration_request` holds the **last** request made, which on this path is normally the *successful* `GET .../message_templates` a few lines above. It has `.json()`, so the first branch is taken; that payload has no `error` key, so `res` is `{}` and `error_message` is `None`.

The result is a dialog titled "Error" with an empty body. The original exception is swallowed, so nothing reaches the Error Log either.

**2. `db_insert()` on an unnamed document**

```python
def upsert_doc_without_hooks(doc, child_dt, child_field):
    if frappe.db.exists(doc.doctype, doc.name):
        ...
    else:
        doc.db_insert()
```

For a template not already in the database, `fetch()` builds the doc with `frappe.new_doc()`, so `doc.name` is still `None`. `db_insert()` does not run autoname, so the insert goes out with `name = NULL` and fails.

### How this was hit

A `hello_world` row (Meta's default template) existed with a blank `actual_name`. The lookup in `fetch()` matches on `actual_name`, so it missed, took the `new_doc()` path, and hit bug 2 — which bug 1 then reported as an empty box. Sync had never completed on that site, with no way to tell why.

### Changes

- Use `frappe.flags.integration_request` only when it actually carries an error payload; otherwise raise the real exception message.
- `frappe.log_error()` with the traceback before throwing, so the cause is recoverable.
- `doc.set_new_name()` when `doc.name` is unset, before the exists/insert branch.

No behaviour change when Meta does return a genuine error: that message is still surfaced with its original title.

### Caveats

- Diagnosed from reading the code plus inspecting the affected site, **not** reproduced on a test bench, so I have no captured traceback to attach. Reproduction should be: blank `actual_name` on a template that also exists on Meta, then run Sync.
- `_` is not imported in this module, so the new messages use plain strings rather than `_()`.
- Possible follow-up, deliberately left out: also matching on the Meta `id`, not just `actual_name`, would stop a blank `actual_name` from causing this in the first place.