### PR TITLE
fix(webhook): ignore status callbacks for unknown wamids

### DIFF
--- a/frappe_whatsapp/utils/test_webhook.py
+++ b/frappe_whatsapp/utils/test_webhook.py
@@ -122,6 +122,16 @@ class TestWebhookHelpers(IntegrationTestCase):
         msg.reload()
         self.assertEqual(msg.status, "sent")
 
+    def test_update_message_status_unknown_wamid_is_a_no_op(self):
+        """A status callback for a wamid we never recorded used to 403 the
+        webhook via get_doc(None) → Guest PermissionError."""
+        update_message_status({
+            "statuses": [{
+                "id": "wamid.webhook_unknown",
+                "status": "delivered",
+            }]
+        })
+
     def test_update_template_status(self):
         """Test update_template_status updates template status via SQL."""
         # Create a template directly

--- a/frappe_whatsapp/utils/webhook.py
+++ b/frappe_whatsapp/utils/webhook.py
@@ -299,9 +299,16 @@ def update_message_status(data):
 	status = data['statuses'][0]['status']
 	conversation = data['statuses'][0].get('conversation', {}).get('id')
 	name = frappe.db.get_value("WhatsApp Message", filters={"message_id": id})
+	if not name:
+		# A status callback for a wamid we never recorded. get_doc(None) used
+		# to raise Guest PermissionError and 403 the webhook, which made the
+		# router log a tenant rejection. There is nothing to update.
+		return
 
-	doc = frappe.get_doc("WhatsApp Message", name)
-	doc.status = status
+	values = {"status": status}
 	if conversation:
-		doc.conversation_id = conversation
-	doc.save(ignore_permissions=True)
+		values["conversation_id"] = conversation
+	# Single UPDATE. Two callbacks for the same message in the same second
+	# used to deadlock on get_doc + save and drop one of them. Concurrent
+	# UPDATEs just last-write-wins on status.
+	frappe.db.set_value("WhatsApp Message", name, values)


### PR DESCRIPTION
A status callback for a `wamid` that is not in the `WhatsApp Message` table takes down the **whole webhook request**, so every status in that payload is lost — not just the unknown one.

### Cause

In `update_message_status()`:

```python
name = frappe.db.get_value("WhatsApp Message", filters={"message_id": id})
doc = frappe.get_doc("WhatsApp Message", name)   # name is None
```

`frappe.db.get_value` returns `None` when the wamid was never recorded, and `frappe.get_doc(dt, None)` then raises. The webhook endpoint runs as Guest, so this surfaces as a permission/DoesNotExist error and the request returns non-200 rather than acknowledging the delivery.

Meta batches statuses, so one unrecognised wamid discards the delivered/read updates for every other message in the same payload.

Unknown wamids are normal in practice: messages sent from the WhatsApp Business app or Manager rather than through Frappe, messages sent before the app was installed, or a number moved between environments while the WABA keeps delivering callbacks for older sends.

### Change

1. Return early when the wamid is unknown. There is nothing to update, and it is not an error condition.
2. Replace `get_doc` + `save` with a single `frappe.db.set_value`. Two callbacks for the same message arriving in the same second (`sent` then `delivered`) could otherwise contend on read-modify-write and drop one; concurrent `UPDATE`s just last-write-wins on status, which is the desired behaviour for a monotonic status field.

### Test

Adds `test_update_message_status_unknown_wamid_is_a_no_op`, which fails on `master` with the raise described above and passes with the change.

Observed in production: a router forwarding Meta callbacks to a tenant site logged 60 rejected forwards over several days, each one an HTTP error from this path, with delivery status silently missing on messages that had in fact been delivered.