### PR TITLE
fix(webhook): persist Meta failure error metadata on failed status

### DIFF
--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification_log/whatsapp_notification_log.json
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification_log/whatsapp_notification_log.json
@@ -7,6 +7,10 @@
  "engine": "InnoDB",
  "field_order": [
   "template",
+  "reference_message",
+  "status",
+  "error_code",
+  "error_message",
   "meta_data"
  ],
  "fields": [
@@ -14,6 +18,34 @@
    "fieldname": "template",
    "fieldtype": "Data",
    "label": "Template"
+  },
+  {
+   "description": "Outgoing WhatsApp Message this log entry relates to, when known.",
+   "fieldname": "reference_message",
+   "fieldtype": "Link",
+   "label": "WhatsApp Message",
+   "options": "WhatsApp Message",
+   "read_only": 1
+  },
+  {
+   "fieldname": "status",
+   "fieldtype": "Data",
+   "in_standard_filter": 1,
+   "label": "Status",
+   "read_only": 1
+  },
+  {
+   "fieldname": "error_code",
+   "fieldtype": "Data",
+   "in_standard_filter": 1,
+   "label": "Error Code",
+   "read_only": 1
+  },
+  {
+   "fieldname": "error_message",
+   "fieldtype": "Small Text",
+   "label": "Error Message",
+   "read_only": 1
   },
   {
    "fieldname": "meta_data",

--- a/frappe_whatsapp/utils/webhook.py
+++ b/frappe_whatsapp/utils/webhook.py
@@ -295,13 +295,57 @@ def update_template_status(data):
 
 def update_message_status(data):
 	"""Update message status."""
-	id = data['statuses'][0]['id']
-	status = data['statuses'][0]['status']
-	conversation = data['statuses'][0].get('conversation', {}).get('id')
+	status_data = data['statuses'][0]
+	id = status_data['id']
+	status = status_data['status']
+	conversation = status_data.get('conversation', {}).get('id')
 	name = frappe.db.get_value("WhatsApp Message", filters={"message_id": id})
+
+	# Meta sends the failure error code/reason only once, on the failed status
+	# callback. Persist it (mapped to the message) before touching the message,
+	# so the reason survives even if the referenced message no longer exists.
+	if status_data.get("errors"):
+		log_message_errors(status_data, name)
+
+	if not name:
+		return
 
 	doc = frappe.get_doc("WhatsApp Message", name)
 	doc.status = status
 	if conversation:
 		doc.conversation_id = conversation
 	doc.save(ignore_permissions=True)
+
+
+def log_message_errors(status_data, message_name=None):
+	"""Record Meta failure metadata in WhatsApp Notification Log.
+
+	Creates one log row per reported error, linked to the originating
+	WhatsApp Message. The full status object is kept in `meta_data` for audit.
+	"""
+	message_id = status_data.get("id")
+
+	# Map the failure to its originating WhatsApp Message so the error is
+	# auditable from the message itself.
+	if not message_name and message_id:
+		message_name = frappe.db.get_value(
+			"WhatsApp Message", filters={"message_id": message_id}
+		)
+
+	for error in status_data.get("errors", []):
+		error_data = error.get("error_data") or {}
+		error_message = error.get("message") or error.get("title")
+		details = error_data.get("details")
+		if details:
+			error_message = f"{error_message}: {details}" if error_message else details
+
+		frappe.get_doc({
+			"doctype": "WhatsApp Notification Log",
+			"template": "Message Failed",
+			"reference_message": message_name,
+			"status": status_data.get("status"),
+			"error_code": error.get("code"),
+			"error_message": error_message,
+			# Whole status object retained verbatim for audit.
+			"meta_data": json.dumps(status_data),
+		}).insert(ignore_permissions=True)


### PR DESCRIPTION
## What & why

When an outgoing WhatsApp message fails, Meta sends the error code/reason **only once**, on the failed message status callback. The webhook handler read the `id` and `status`, flipped the message to `failed`, and discarded the rest — including the `errors[]` array. As a result the failure reason could not be looked up retroactively in Frappe; you had to trap it live the next time it happened.

This persists that error metadata so failures are diagnosable after the fact.

## Changes

- **`WhatsApp Notification Log`** gains four fields:
  - `reference_message` — Link to the originating `WhatsApp Message` (maps each failure to its message)
  - `status` — e.g. `failed` (standard filter)
  - `error_code` — Meta error code (standard filter)
  - `error_message` — human-readable reason, with `error_data.details` appended when present
  - `meta_data` still stores the **complete** status object verbatim for audit.
- **`update_message_status`** now records failures via a new `log_message_errors` helper when the status callback carries `errors[]` — one log row per reported error, mapped to the message.
- Fixes a latent crash: `update_message_status` previously called `frappe.get_doc("WhatsApp Message", None)` when no message matched the callback's message id; it now returns cleanly.

## Notes for reviewers

- Reused the existing `WhatsApp Notification Log` rather than adding a new doctype, so failure data lives alongside the other webhook logs and needs no new maintenance surface.
- Fields map to Meta's Cloud API status-webhook schema (`statuses[].errors[].{code,title,message,error_data.details,href}`).
- Requires `bench migrate` to apply the new fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)