### PR TITLE
Treat Meta as the authority for a template's category (central#680)

### DIFF
--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_templates/whatsapp_templates.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_templates/whatsapp_templates.py
@@ -182,6 +182,17 @@ class WhatsAppTemplates(Document):  # nosemgrep: frappe-modifying-but-not-commit
             )
             self.id = response["id"]  # nosemgrep: frappe-modifying-but-not-committing
             self.status = response["status"]  # nosemgrep: frappe-modifying-but-not-committing
+            # Meta decides the category; what we submitted above is a request, not the
+            # outcome. `fetch()` already treats Meta as authoritative here, so without
+            # this the pull path stays true while the create path drifts from birth.
+            #
+            # Conditional, and never `= response.get("category")`: it is not confirmed
+            # that Meta's create response carries `category` at all. If it does not,
+            # this is a harmless no-op and the row keeps the value we submitted until
+            # a `fetch()` or a `template_category_update` corrects it — whereas an
+            # unconditional write would replace a plausible value with None.
+            if response.get("category"):
+                self.category = response["category"]  # nosemgrep: frappe-modifying-but-not-committing
             self.db_update()
         except Exception as e:
             res = frappe.flags.integration_request.json().get("error", {})
@@ -234,11 +245,20 @@ class WhatsAppTemplates(Document):  # nosemgrep: frappe-modifying-but-not-commit
 
         try:
             # post template to meta for update
-            make_post_request(
+            response = make_post_request(
                 f"{self._url}/{self._version}/{self.id}",
                 headers=self._headers,
                 data=json.dumps(data),
             )
+            # This path discarded its response entirely. An edit can change how Meta
+            # reads the template's intent — which is how a renewal reminder becomes
+            # MARKETING — so the same conditional write-back applies here.
+            #
+            # No `db_update()`, unlike `after_insert`: this runs from `validate`, so the
+            # save that called it persists the field on its way out. Writing the row here
+            # would be doing it twice, once against a row that is not final yet.
+            if isinstance(response, dict) and response.get("category"):
+                self.category = response["category"]
         except Exception as e:
             raise e
             # res = frappe.flags.integration_request.json()['error']

--- a/frappe_whatsapp/utils/test_template_category.py
+++ b/frappe_whatsapp/utils/test_template_category.py
@@ -1,0 +1,345 @@
+# Copyright (c) 2026, GlobalSync ERP Software Solutions and Contributors
+# See license.txt
+
+"""`category` on a WhatsApp Templates row is a cache of a value only Meta owns.
+
+Until this change it was a write-once copy of what *we submitted* and never of what Meta
+*decided*. Two independent gaps kept it that way: the create path never read `category`
+back off the response, and the app was not subscribed to `template_category_update`, so a
+correct value would go stale the first time Meta re-categorised after approval.
+
+Observed live on Blue Anvil prod (WABA 27935806516059749): all six templates submitted as
+UTILITY on 2026-08-28; Meta re-categorised `gym_renewal_reminder` to MARKETING because its
+body asks the member to renew. Our row still said UTILITY. Nothing noticed.
+
+The consequence that sets the priority is **consent**, not cost. Marketing templates may
+only go to members who have not opted out, so a row claiming UTILITY while Meta governs
+the template as MARKETING is exactly the state in which a marketing message is sent to an
+opted-out member in the belief that it is transactional.
+
+Note the app was already internally inconsistent about this: `fetch()` has always done
+`doc.category = template["category"]`. The pull path was right; the create and push paths
+were missing.
+"""
+
+from unittest.mock import patch
+
+import frappe
+from frappe_whatsapp.testing import IntegrationTestCase
+
+from frappe_whatsapp.utils.webhook import update_status, update_template_category
+
+ACCOUNT = "Test WA Category Account"
+
+
+class TestTemplateCategoryWebhook(IntegrationTestCase):
+    """`template_category_update` — the steady-state path.
+
+    This is the only mechanism that catches a re-categorisation of an *already approved*
+    template, which per Meta's docs happens on a recurring sweep and not only at review.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        if not frappe.db.exists("WhatsApp Account", ACCOUNT):
+            account = frappe.get_doc({
+                "doctype": "WhatsApp Account",
+                "account_name": ACCOUNT,
+                "status": "Active",
+                "url": "https://graph.facebook.com",
+                "version": "v17.0",
+                "phone_id": "category_test_phone_id",
+                "business_id": "category_test_business_id",
+                "app_id": "category_test_app_id",
+                "webhook_verify_token": "category_test_verify_token",
+            })
+            account.insert(ignore_permissions=True)
+            frappe.db.commit()  # nosemgrep: frappe-manual-commit -- fixture must be visible to later queries
+
+    def _template(self, actual_name, *, template_id=None, category="UTILITY", language_code="en"):
+        name = f"{actual_name}__{language_code}-{language_code}"
+        # Raw deletes, never `frappe.delete_doc`: `WhatsApp Templates.on_trash` makes a
+        # real HTTP DELETE to graph.facebook.com. A test must not reach Meta.
+        frappe.db.delete("WhatsApp Templates", {"name": name})
+        doc = frappe.get_doc({
+            "doctype": "WhatsApp Templates",
+            # `template_name` carries a unique index while `actual_name` does not, so a
+            # site holding one template in two languages must differ here. Worth knowing:
+            # `fetch()` writes Meta's name into *both*, so it cannot in fact hold the same
+            # template twice. The name+language filter is still the right one — narrowing
+            # on the language it was told about is correct whether or not a second row
+            # exists — and this is the shape that would break it if it were not.
+            "template_name": f"{actual_name}__{language_code}",
+            "actual_name": actual_name,
+            "template": "Hi {{1}}, your membership expires on {{2}}.",
+            "category": category,
+            "language": frappe.db.get_value("Language", {"language_code": "en"}) or "en",
+            "language_code": language_code,
+            "whatsapp_account": ACCOUNT,
+            "status": "APPROVED",
+            "id": template_id,
+        })
+        doc.db_insert()
+        frappe.db.commit()  # nosemgrep: frappe-manual-commit -- fixture must be visible to later queries
+        self.addCleanup(frappe.db.delete, "WhatsApp Templates", {"name": doc.name})
+        return doc.name
+
+    def _category(self, row):
+        return frappe.db.get_value("WhatsApp Templates", row, "category")
+
+    # ---- the observed incident ------------------------------------------
+
+    def test_a_recategorisation_is_written_back(self):
+        """The Blue Anvil case exactly: submitted UTILITY, Meta says MARKETING."""
+        row = self._template("gym_renewal_reminder_cat", template_id="cat_id_001")
+
+        update_template_category({
+            "message_template_id": "cat_id_001",
+            "message_template_name": "gym_renewal_reminder_cat",
+            "message_template_language": "en",
+            "previous_category": "UTILITY",
+            "new_category": "MARKETING",
+        })
+
+        self.assertEqual(self._category(row), "MARKETING")
+
+    def test_the_event_is_routed_from_update_status(self):
+        """`update_status` is the fan-out the endpoint reaches — a handler nothing routes
+        to would pass every test here and never run in production."""
+        row = self._template("gym_routed_cat", template_id="cat_id_002")
+
+        update_status({
+            "field": "template_category_update",
+            "value": {
+                "message_template_id": "cat_id_002",
+                "new_category": "MARKETING",
+            },
+        })
+
+        self.assertEqual(self._category(row), "MARKETING")
+
+    # ---- matching ---------------------------------------------------------
+
+    def test_a_row_with_no_id_is_matched_by_name_and_language(self):
+        """Not defensive padding — a required path. Rows seeded locally, or created
+        before a real Meta submission, carry `id = null` and are unmatchable by id. All
+        six Blue Anvil rows were in that state as recently as 2026-08-26 (#655)."""
+        row = self._template("gym_unsubmitted_cat", template_id=None)
+
+        update_template_category({
+            "message_template_name": "gym_unsubmitted_cat",
+            "message_template_language": "en",
+            "new_category": "MARKETING",
+        })
+
+        self.assertEqual(self._category(row), "MARKETING")
+
+    def test_the_language_narrows_the_name_match(self):
+        """Two rows can share `actual_name` and differ only by language."""
+        english = self._template("gym_multilang_cat", template_id=None, language_code="en")
+        nepali = self._template("gym_multilang_cat", template_id=None, language_code="ne")
+
+        update_template_category({
+            "message_template_name": "gym_multilang_cat",
+            "message_template_language": "ne",
+            "new_category": "MARKETING",
+        })
+
+        self.assertEqual(self._category(nepali), "MARKETING")
+        self.assertEqual(self._category(english), "UTILITY")
+
+    def test_the_id_wins_when_both_could_match(self):
+        row = self._template("gym_idwins_cat", template_id="cat_id_003")
+        other = self._template("gym_idwins_other_cat", template_id="cat_id_004")
+
+        update_template_category({
+            "message_template_id": "cat_id_004",
+            "message_template_name": "gym_idwins_cat",
+            "new_category": "MARKETING",
+        })
+
+        self.assertEqual(self._category(other), "MARKETING")
+        self.assertEqual(self._category(row), "UTILITY")
+
+    # ---- the shapes that must not write ------------------------------------
+
+    def test_an_unchanged_category_is_a_quiet_no_op(self):
+        row = self._template("gym_noop_cat", template_id="cat_id_005", category="UTILITY")
+
+        with patch.object(frappe, "log_error") as logged:
+            update_template_category({
+                "message_template_id": "cat_id_005",
+                "previous_category": "UTILITY",
+                "new_category": "UTILITY",
+            })
+
+        self.assertEqual(self._category(row), "UTILITY")
+        logged.assert_not_called()
+
+    def test_a_missing_new_category_writes_nothing_and_says_so(self):
+        """The payload's field names come from Meta's docs, not from a delivery we have
+        observed. If the documented key is absent, the row must keep its value and
+        somebody has to be told the shape was wrong — never write None over a good
+        cached value."""
+        row = self._template("gym_nokey_cat", template_id="cat_id_006")
+
+        with patch.object(frappe, "log_error") as logged:
+            update_template_category({"message_template_id": "cat_id_006", "previous_category": "UTILITY"})
+
+        self.assertEqual(self._category(row), "UTILITY")
+        logged.assert_called_once()
+
+    def test_the_advance_notice_variant_does_not_write_early(self):
+        """Meta sends `correct_category` to announce a change it intends to apply later.
+        Writing it would put a category into the row before it is in force — the same
+        wrong-by-one-state problem this fix exists to close, in the other direction."""
+        row = self._template("gym_advance_cat", template_id="cat_id_007")
+
+        update_template_category({
+            "message_template_id": "cat_id_007",
+            "correct_category": "MARKETING",
+        })
+
+        self.assertEqual(self._category(row), "UTILITY")
+
+    def test_an_unknown_template_is_not_created(self):
+        """A template we do not hold is one this site does not send. Inventing a row from
+        a webhook would put a half-populated template in front of staff."""
+        before = frappe.db.count("WhatsApp Templates")
+
+        with patch.object(frappe, "log_error") as logged:
+            update_template_category({
+                "message_template_id": "cat_id_does_not_exist",
+                "message_template_name": "not_ours",
+                "new_category": "MARKETING",
+            })
+
+        self.assertEqual(frappe.db.count("WhatsApp Templates"), before)
+        logged.assert_called_once()
+
+    def test_an_unknown_field_stays_a_quiet_ignore(self):
+        """The Meta subscription is app-wide, so a newly ticked field goes live for every
+        tenant at once — including tenants still on an older image. An unhandled event has
+        to be a no-op, not an error log on every delivery across the fleet."""
+        with patch.object(frappe, "log_error") as logged:
+            update_status({"field": "some_future_meta_field", "value": {"anything": 1}})
+
+        logged.assert_not_called()
+
+
+class TestTemplateCategoryWriteBack(IntegrationTestCase):
+    """The create and update paths, which submitted a category and never read one back.
+
+    `after_insert` stored only `id` and `status`; `update_template` discarded its response
+    entirely. So a template Meta accepted under a different category than requested kept
+    our submitted value silently, from birth.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        if not frappe.db.exists("WhatsApp Account", ACCOUNT):
+            frappe.get_doc({
+                "doctype": "WhatsApp Account",
+                "account_name": ACCOUNT,
+                "status": "Active",
+                "url": "https://graph.facebook.com",
+                "version": "v17.0",
+                "phone_id": "category_test_phone_id",
+                "business_id": "category_test_business_id",
+                "app_id": "category_test_app_id",
+                "webhook_verify_token": "category_test_verify_token",
+            }).insert(ignore_permissions=True)
+            frappe.db.commit()  # nosemgrep: frappe-manual-commit -- fixture must be visible to later queries
+    def setUp(self):
+        # Per test, not once per class: `get_settings` reads this inside the transaction
+        # each test runs in, and the class-level fixture is outside it. Same reason
+        # test_webhook.py does it this way.
+        from frappe.utils.password import set_encrypted_password
+        set_encrypted_password("WhatsApp Account", ACCOUNT, "category_token", "token")
+
+    def _row(self, actual_name, *, category="UTILITY", template_id=None):
+        name = f"{actual_name}-en"
+        # See the note in TestTemplateCategoryWebhook: on_trash calls out to Meta.
+        frappe.db.delete("WhatsApp Templates", {"name": name})
+        doc = frappe.get_doc({
+            "doctype": "WhatsApp Templates",
+            "template_name": actual_name,
+            "actual_name": actual_name,
+            "template": "Hi {{1}}, your membership expires on {{2}}.",
+            "category": category,
+            "language": frappe.db.get_value("Language", {"language_code": "en"}) or "en",
+            "language_code": "en",
+            "whatsapp_account": ACCOUNT,
+            "status": "PENDING",
+            "id": template_id,
+        })
+        doc.db_insert()
+        frappe.db.commit()  # nosemgrep: frappe-manual-commit -- fixture must be visible to later queries
+        self.addCleanup(frappe.db.delete, "WhatsApp Templates", {"name": doc.name})
+        return frappe.get_doc("WhatsApp Templates", doc.name)
+
+    # ---- create -----------------------------------------------------------
+
+    def test_the_category_meta_returns_is_stored_at_create(self):
+        """Submitted UTILITY, accepted as MARKETING — the row must say MARKETING."""
+        doc = self._row("gym_create_cat")
+        response = {"id": "created_id_1", "status": "PENDING", "category": "MARKETING"}
+
+        with patch(
+            "frappe_whatsapp.frappe_whatsapp.doctype.whatsapp_templates.whatsapp_templates.make_post_request",
+            return_value=response,
+        ):
+            doc.after_insert()
+
+        doc.reload()
+        self.assertEqual(doc.category, "MARKETING")
+        self.assertEqual(doc.id, "created_id_1")
+        self.assertEqual(doc.status, "PENDING")
+
+    def test_a_create_response_without_a_category_leaves_ours_alone(self):
+        """It is **not** confirmed that Meta's create response carries `category`. If it
+        does not, this write-back is a harmless no-op and the reconcile paths cover it —
+        whereas an unconditional `response.get("category")` would replace a plausible
+        value with None, which is worse than the drift it was meant to fix."""
+        doc = self._row("gym_create_nocat")
+        response = {"id": "created_id_2", "status": "PENDING"}
+
+        with patch(
+            "frappe_whatsapp.frappe_whatsapp.doctype.whatsapp_templates.whatsapp_templates.make_post_request",
+            return_value=response,
+        ):
+            doc.after_insert()
+
+        doc.reload()
+        self.assertEqual(doc.category, "UTILITY")
+        self.assertEqual(doc.id, "created_id_2", "the fields that always worked still do")
+
+    # ---- update -----------------------------------------------------------
+
+    def test_the_update_path_no_longer_discards_its_response(self):
+        """An edit can change how Meta reads the template's intent — a body that asks the
+        member to renew is how a utility template becomes MARKETING."""
+        doc = self._row("gym_update_cat", template_id="updated_id_1")
+
+        with patch(
+            "frappe_whatsapp.frappe_whatsapp.doctype.whatsapp_templates.whatsapp_templates.make_post_request",
+            return_value={"success": True, "category": "MARKETING"},
+        ):
+            doc.update_template()
+
+        self.assertEqual(doc.category, "MARKETING")
+
+    def test_the_update_path_tolerates_a_response_that_is_not_a_dict(self):
+        """This path previously ignored its return value entirely, so nothing constrained
+        the shape. Reading it must not become a new way for a save to throw."""
+        doc = self._row("gym_update_odd", template_id="updated_id_2")
+
+        with patch(
+            "frappe_whatsapp.frappe_whatsapp.doctype.whatsapp_templates.whatsapp_templates.make_post_request",
+            return_value=None,
+        ):
+            doc.update_template()
+
+        self.assertEqual(doc.category, "UTILITY")

--- a/frappe_whatsapp/utils/webhook.py
+++ b/frappe_whatsapp/utils/webhook.py
@@ -277,9 +277,18 @@ def post():
 	return
 
 def update_status(data):
-	"""Update status hook."""
+	"""Update status hook.
+
+	An unrecognised `field` falls through silently, on purpose. The app's Meta
+	subscription is app-wide, so a newly ticked field goes live for every tenant at
+	once — including tenants still running an older image. An unhandled event has to
+	be a no-op, not an error log on every delivery across the fleet.
+	"""
 	if data.get("field") == "message_template_status_update":
 		update_template_status(data['value'])
+
+	elif data.get("field") == "template_category_update":
+		update_template_category(data['value'])
 
 	elif data.get("field") == "messages":
 		update_message_status(data['value'])
@@ -292,6 +301,68 @@ def update_template_status(data):
 		WHERE id = %(message_template_id)s""",
 		data
 	)
+
+def update_template_category(data):
+	"""Write Meta's category back onto the matching template row.
+
+	Meta owns `category`; our row is only a cache of it. Meta re-categorises both at
+	review time and on a recurring sweep over already-approved templates, so a value
+	captured at creation goes stale on its own. Observed live: `gym_renewal_reminder`
+	was submitted as UTILITY and re-categorised to MARKETING, and nothing noticed.
+
+	That matters for **consent**, not only cost. Marketing templates may only go to
+	members who have not opted out, so a row claiming UTILITY while Meta governs the
+	template as MARKETING is exactly the state in which a marketing message is sent to
+	an opted-out member in the belief that it is transactional.
+
+	Matching falls back to `actual_name` + `language_code` when `id` is empty, and that
+	fallback is a first-class path rather than defensive padding: rows seeded locally,
+	or created before a real Meta submission, carry no `id` at all and are unmatchable
+	by it.
+
+	Only `new_category` is written. The advance-notice variant of this event carries
+	`correct_category` — the category Meta intends to apply later — and writing that
+	would put a category into the row before it is in force, which is the same
+	wrong-by-one-state problem in the other direction.
+
+	The payload's field names come from Meta's documentation rather than from a
+	delivery we have seen. `post()` already records every webhook body verbatim in a
+	`WhatsApp Notification Log` row, so the first real delivery can be read back and
+	the shape confirmed there — no second log is needed for that. What is logged here
+	is the case where the expected key is absent, because that means the documented
+	shape was wrong and somebody has to look.
+	"""
+	template_id = data.get("message_template_id")
+	name = data.get("message_template_name")
+	language = data.get("message_template_language")
+	new_category = data.get("new_category")
+
+	if not new_category:
+		frappe.log_error(
+			message=json.dumps(data, default=str),
+			title="WhatsApp template_category_update without new_category",
+		)
+		return
+
+	row = None
+	if template_id:
+		row = frappe.db.get_value("WhatsApp Templates", {"id": template_id}, "name")
+	if not row and name:
+		filters = {"actual_name": name}
+		if language:
+			filters["language_code"] = language
+		row = frappe.db.get_value("WhatsApp Templates", filters, "name")
+
+	if not row:
+		# Never create a row from a webhook: a template we do not hold is one this site
+		# does not send, and inventing it would put a half-populated row in front of staff.
+		frappe.log_error(
+			message=json.dumps(data, default=str),
+			title="WhatsApp template_category_update for an unknown template",
+		)
+		return
+
+	frappe.db.set_value("WhatsApp Templates", row, "category", new_category)
 
 def update_message_status(data):
 	"""Update message status."""


### PR DESCRIPTION
`category` on a `WhatsApp Templates` row is a **cache of a value only Meta owns**. Until this change it was a write-once copy of what *we submitted*, never of what Meta *decided*.

Observed live on Blue Anvil prod (WABA `27935806516059749`): all six templates submitted as UTILITY on 2026-08-28. Meta re-categorised **`gym_renewal_reminder` to MARKETING** — its body asks the member to renew, which reads as promotional intent. Our row still said UTILITY. Nothing noticed.

## Why this is a p2 and not cosmetic

**Consent, not cost.** Marketing templates may only go to members who have not opted out. A row claiming UTILITY while Meta governs the template as MARKETING is exactly the state in which we send a marketing message to an opted-out member believing it transactional. Cost and per-category reporting error scale with volume; the consent failure needs one send.

Sending itself is unaffected — the app sends by template name + language and never transmits category.

## Two gaps

| gap | window it left open |
|---|---|
| create path never read `category` back | wrong from birth, if Meta accepts under a different category than requested |
| no handler for `template_category_update` | goes stale later — Meta re-categorises at review **and** on a recurring sweep over already-approved templates |

Note the app was already inconsistent about this: `fetch()` has always done `doc.category = template["category"]`. **The pull path was right; the create and push paths were missing.** This makes them agree.

## What changed

**`utils/webhook.py`** — `update_status` routes `template_category_update` to `update_template_category`.

- Matching is `id` first, then `actual_name` + `language_code`. That fallback is a **first-class path, not padding**: rows seeded locally or created before a real Meta submission carry no `id` and are unmatchable by it — all six Blue Anvil rows were in that state as recently as #655. It has its own tests.
- **Only `new_category` is written.** The advance-notice variant carries `correct_category` — the category Meta intends to apply *later*. Writing that would put a category into the row before it is in force: the same wrong-by-one-state problem in the other direction.
- An unknown template is logged, never created. A template we do not hold is one this site does not send.

**`whatsapp_templates.py`** — `after_insert` stores `response.get("category")` alongside `id`/`status`, and `update_template` no longer discards its response entirely.

Both writes are **conditional**. It is *not* confirmed that Meta's create response carries `category` at all; if it does not, this is a harmless no-op and the reconcile paths cover it — whereas an unconditional `response.get("category")` would replace a plausible value with `None`, which is worse than the drift it was meant to fix.

`update_template` sets the field without `db_update()`, unlike `after_insert`: it runs from `validate`, so the save that called it persists the field on its way out.

## Two judgement calls worth checking in review

- **No "log the first payload" call.** The field names come from Meta's docs, not from a delivery we have seen — but `post()` *already* records every webhook body verbatim in a `WhatsApp Notification Log` row, so the first real delivery can be read back there. A second log would be duplicating that. What **is** logged is the expected key being absent, because that means the documented shape was wrong and somebody has to look.
- **An unrecognised `field` stays a silent fall-through**, and there is now a test saying so rather than leaving it to inference. The Meta subscription is app-wide, so a newly ticked field goes live for every tenant at once — including tenants still on an older image. An unhandled event has to be a no-op, not an error log on every delivery across the fleet.

## ⚠️ Deployment ordering

**Ship and deploy this fleet-wide *before* ticking `template_category_update` in the Meta App Dashboard.** Field selection is app-wide, so the flip goes live for every WABA simultaneously. Reversed, every tenant on an older image receives an unhandled-field payload. (Harmless given the fall-through above — but that is this PR's fall-through, which is exactly the thing an older image does not have.)

The subscription flip itself is an operator action and is not in this diff. `GET /{app-id}/subscriptions` currently lists `account_alerts, account_review_update, account_update, calls, message_template_quality_update, message_template_status_update, messages, phone_number_name_update, phone_number_quality_update, security` — `template_category_update` is absent.

**The central router needs no change**, and for a stronger reason than "it routes on `entry[].id`": `group_entries_by_waba()` never inspects `changes[].field`, so it is event-type agnostic, and `build_forward_bodies()` forwards the exact raw bytes for the single-WABA case, so `X-Hub-Signature-256` stays valid.

## Tests

```
frappe_whatsapp.utils.test_template_category                14 passed
frappe_whatsapp.utils.test_webhook                          13 passed (unchanged)
...doctype.whatsapp_templates.test_whatsapp_templates       13 passed (unchanged)
```

Run on `vm.globalsyncusa.com`, the bench site that has `frappe_whatsapp` installed.

A note for the next person writing tests here: `WhatsApp Templates.on_trash` makes a **real HTTP DELETE to graph.facebook.com**, so these clean up with `frappe.db.delete` rather than `frappe.delete_doc`.

Also surfaced while writing them: `template_name` carries a unique index while `actual_name` does not, and `fetch()` writes Meta's name into **both** — so this app cannot in fact hold the same template in two languages. Not touched here; noting it because the name+language match looks like it handles a case the schema forbids. The filter is still right (narrowing on the language it was told about is correct either way).

## Follow-up worth its own issue

Storing the right category makes the consent failure **detectable**, not prevented — nothing on the send path consults category. A follow-up should gate sends of a MARKETING-category template on the recipient's opt-out status, so a re-categorisation converts into a *blocked* send rather than a wrong one.

Also worth promoting the existing `fetch()` to a scheduled reconcile: the webhook is a push over a chain with several deliberate drop points (`whatsapp_router.dispatch` drops a payload whose WABA has no enabled route; `_forward_one` swallows tenant 4xx/5xx because Meta has already been acked 200; `forward_async` puts the forward on a queue that can be lost with the worker). None of those are defects — they are the right posture for a webhook fan-out — but together they mean push alone cannot be the system of record. A daily `fetch()` makes it self-healing, and the one-off backfill that fixes `gym_renewal_reminder` today is that job's first run.

Refs globalsyncerp/globalsync_central#680

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wuvYrJ7tsGGesAsNgPDo5