### PR TITLE
Fix body_param handling in send_template (TypeError/AttributeError on JSON field)

### DIFF
--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/whatsapp_message.py
@@ -214,7 +214,26 @@ class WhatsAppMessage(Document):
             field_names = template.field_names.split(",") if template.field_names else template.sample_values.split(",")
 
             if self.body_param is not None:
-                params = list(json.loads(self.body_param).values())
+                # `body_param` is fieldtype JSON, so Frappe's ORM already
+                # deserializes it into a Python dict/list on read -- it is
+                # NOT a raw JSON string. Calling json.loads() on it (as this
+                # used to do unconditionally) broke two ways depending on
+                # what the caller sent: TypeError "must be str, bytes or
+                # bytearray, not list/dict" when it was already parsed, or
+                # AttributeError "'list' object has no attribute 'values'"
+                # when a JSON array string was passed instead of an object
+                # string. Accept a str (legacy callers may still pass one),
+                # a dict (keyed params, existing convention), or a list
+                # (already-ordered params) uniformly.
+                bp = self.body_param
+                if isinstance(bp, str):
+                    bp = json.loads(bp)
+                if isinstance(bp, dict):
+                    params = list(bp.values())
+                elif isinstance(bp, list):
+                    params = bp
+                else:
+                    params = []
                 for param in params:
                     parameters.append({"type": "text", "text": param})
                     template_parameters.append(param)


### PR DESCRIPTION
## Problem

`body_param` on WhatsApp Message is fieldtype `JSON`, so Frappe's ORM already deserializes it into a Python `dict`/`list` on read -- it is never a raw JSON string in normal operation. `send_template()` unconditionally called `json.loads(self.body_param).values()`, which broke two different ways depending on what was actually stored, both seen in production:

- `TypeError: the JSON object must be str, bytes or bytearray, not list` -- when `body_param` was already parsed by the ORM (the common case for a JSON-typed field).
- `AttributeError: 'list' object has no attribute 'values'` -- when `body_param` held a JSON array instead of a JSON object.

Either way, no template message could send when `body_param` came in as anything other than a raw JSON-object string.

## Fix

Normalize `body_param` to a plain ordered `params` list up front, handling all three shapes it can realistically take: `str` (legacy raw JSON, still `json.loads`'d), `dict` (existing keyed-params convention, `.values()`), or `list` (already-ordered params, used as-is).

## Testing

Extracted the exact logic into an isolated unit test covering all four input shapes (already-a-list, already-a-dict, JSON string of an object, JSON string of an array) -- all four now produce identical, correct output with no exception. File still passes `python3 -m py_compile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)