### PR TITLE
Fix empty template dropdown in Send To Whatsapp dialog, mislabeled Telegram title

### DIFF
--- a/frappe_whatsapp/public/js/frappe_whatsapp.js
+++ b/frappe_whatsapp/public/js/frappe_whatsapp.js
@@ -2,7 +2,7 @@ $(document).on('app_ready', function () {
 	// waiting for page to load completely
 	frappe.router.on("change", () => {
 		var route = frappe.get_route();
-		// all form's menu add the 'Send To Telegram' funcationality
+		// all form's menu add the 'Send To Whatsapp' functionality
 		if (route && route[0] == "Form") {
 			frappe.ui.form.on(route[1], {
 				refresh: function (frm) {
@@ -44,7 +44,7 @@ $(document).on('app_ready', function () {
 
 							],
 							'primary_action_label': 'Send',
-							'title': 'Send a Telegram Message',
+							'title': 'Send a Whatsapp Message',
 							primary_action: function () {
 								var values = dialog.get_values();
 								if (values) {
@@ -88,8 +88,17 @@ $(document).on('app_ready', function () {
 	                    if (template) {
 	                        // Dynamically set the get_query function for the user field
 	                        template.get_query = function() {
+	                            // for_doctype is an optional tag on WhatsApp Templates and
+	                            // is NULL (not empty string) on every template in practice --
+	                            // filtering strictly on for_doctype = <this form's doctype>
+	                            // meant SQL "IN ('', 'Sales Invoice')" never matched NULL,
+	                            // so the dropdown came back empty on every single form.
+	                            // Show any Meta-approved template regardless of tagging
+	                            // (Pending ones would fail at send time anyway); re-add a
+	                            // proper doctype filter later once templates are actually
+	                            // tagged with for_doctype.
 	                            return {
-	                                filters: { "for_doctype": frm.doc.doctype },
+	                                filters: { "status": "APPROVED" },
 	                                doctype: "WhatsApp Templates"
 	                            };
 	                        };


### PR DESCRIPTION
## Problem

The "Send To Whatsapp" form menu item (added to every doctype's form) filters its template Link field with `filters: { "for_doctype": frm.doc.doctype }`. In practice `for_doctype` is an optional field on WhatsApp Templates that is essentially never set -- it's stored as SQL `NULL`, not empty string. Frappe's Link-field query translates the filter to `for_doctype IN ('', '<doctype>')`, and `IN (...)` never matches `NULL` in SQL, so the dropdown came back completely empty on every single form, for every user, regardless of how many approved templates existed.

Separately, the dialog is titled `'Send a Telegram Message'` (and the surrounding code comment says `Send To Telegram funcationality`) even though the actual send logic always calls the WhatsApp `send_template` method -- a copy-paste leftover, not a wrong-channel bug, but confusing enough that a user reported it as "showing Telegram thing instead of WhatsApp".

## Fix

- Drop the `for_doctype` filter (since it's unpopulated in practice) and filter by `status: "APPROVED"` instead, so any Meta-approved template shows up regardless of doctype tagging. A proper doctype-aware filter can be reintroduced once/if templates are actually tagged with `for_doctype` going forward.
- Rename the dialog title to `'Send a Whatsapp Message'` and fix the stale comment.

## Testing

Confirmed on a live instance: before the fix, the WhatsApp Templates dropdown returned zero results on every form despite 20+ APPROVED templates existing; after the fix, approved templates populate correctly. `node --check` passes on the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)